### PR TITLE
Initial docker dev stuff

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+Dockerfile*
+docker-compose*

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,4 @@
+FROM php:apache
+RUN apt update && apt install -y libcurl4-openssl-dev
+RUN a2enmod headers
+RUN docker-php-ext-install curl pdo pdo_mysql mysqli

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,18 @@
 FROM php:apache
-RUN apt update && apt install -y libcurl4-openssl-dev
+ENV APP_DIR=/var/www/html
+
+RUN useradd -u 1000 ciab
+RUN apt update && apt install -y libcurl4-openssl-dev libzip-dev zlib1g-dev git
 RUN a2enmod headers
-RUN docker-php-ext-install curl pdo pdo_mysql mysqli
+RUN docker-php-ext-install curl pdo pdo_mysql mysqli zip
+#Install Composer
+RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+RUN php composer-setup.php --install-dir=. --filename=composer
+RUN mv composer /usr/local/bin/
+
+VOLUME ${APP_DIR}
+WORKDIR ${APP_DIR}
+COPY --chown=ciab . /var/www/html
+COPY docker-entrypoint.sh /
+ENTRYPOINT ["/bin/bash", "/docker-entrypoint.sh"]
+CMD ["dev"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,31 @@
+version: "3.7"
+services:
+  app:
+    build: 
+      context: .
+      dockerfile: Dockerfile.dev
+    environment:
+      APACHE_RUN_USER: '#1000'
+      APACHE_RUN_GROUP: '#1000'
+    links:
+      - db
+    ports:
+      - 80:80
+    volumes:
+      - .:/var/www/html
+
+  db:
+    image: mysql:5.7
+    environment:
+      MYSQL_DATABASE: ciab
+      MYSQL_ONETIME_PASSWORD: 1
+      MYSQL_PASSWORD: llama
+      MYSQL_RANDOM_ROOT_PASSWORD: 1
+      MYSQL_USER: ciab
+    ports:
+      - 3306:3306
+    volumes:
+      - datadir:/var/lib/mysql
+volumes:
+  datadir:
+

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+COMPOSER=/usr/local/bin/composer
+
+cd ${APP_DIR}
+${COMPOSER} install
+chown -R ciab ${APP_DIR}
+chmod u+s ${APP_DIR}
+if [ "$1" = 'dev' ]; then
+  exec docker-php-entrypoint apache2-foreground
+fi
+
+exec $@


### PR DESCRIPTION
`Dockerfile.dev` will build a simple PHP-Apache docker environment. It will **not** copy in the source tree (the way Bryce's Dockerfile will) because...

`docker-compose.yml` will bring up mysql 5.7 and the app's docker image and link them, and grab port 80. Everything should more or less behave as if it were local, with one exception: the `.ht_blahblah` file for some reason is getting created with root perms despite Apache running as user 1000 (on the assumption that your logged in Linux user is likely user 1000). This can be easily fixed with a `sudo chown` and at some point I'll figure out how to make it not happen.

The one other thing you need to do now is run `composer install` locally. My next step is to figure out a clever way to have docker-compose run a startup script in the image that will do this if it's necessary, and only then proceed to start up Apache.