### PR TITLE
Composer in Docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,12 @@ services:
         DBPASS: ${DBPASS}
         DBUSER: ${DBUSER}
         DOCKER: 1
+  composer:
+    restart: 'no'
+    image: "composer"
+    command: install
+    volumes:
+      - .:/app
   apache:
     build: './docker/apache/'
     depends_on:

--- a/style.php
+++ b/style.php
@@ -5,14 +5,17 @@
 
 require_once __DIR__."/vendor/autoload.php";
 
+const RESOURCE_CACHE = 'resources/scss_cache';
+
 $scss = new scssc();
 $scss->addImportPath("scss");
 $scss->setFormatter("scss_formatter_compressed");
 
 $uri = explode("/", $_SERVER['REQUEST_URI']);
 
-if (!is_dir('resources/scss_cache')) {
-    @mkdir('resources/scss_cache', 0777, true);
+if (!is_dir(RESOURCE_CACHE)) {
+    @mkdir(RESOURCE_CACHE, 0777, true);
+    @chmod(RESOURCE_CACHE, 0777);
 }
 
 $MODULESDIR = "modules";


### PR DESCRIPTION
With these changes I believe a fresh clean source tree should be able to be started with `./docker_instance up` and update all the php vendor stuff and everything. Ready to directly use. 