### PR TITLE
Placeholder - user support for past credit

### DIFF
--- a/data/database-schema.php
+++ b/data/database-schema.php
@@ -1,225 +1,237 @@
 <?php
 
 // CON-In-A-Box DB Schema
-// 2018 Thomas Keeley
-
 // The Current CIAB DB Schema in an array for checking and applying
 
 class SCHEMA
 {
-  public static $REQUIED_DB_SCHEMA = 2018092400; // Current DB Version - YYYYMMDDvv format (vv=daily counter form 00)
 
-  public static $DB_tables = [
-    'ActivityLog' => [
-        'LogEntryID' => 'INT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT',
-        'AccountID' => 'INT UNSIGNED NOT NULL', // Use 0 for System AccountID
-        'Function' => 'VARCHAR(100) NOT NULL',
-        'Query' => 'TEXT NOT NULL',
-        'Date' => 'TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP',
-    ],
-    'AnnualCycles' => [ // Bylaw defined "year", used for tracking
-        'AnnualCycleID' => 'INT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT',
-        'DateFrom' => 'DATE NOT NULL',
-        'DateTo' => 'DATE NOT NULL',
-    ],
-    'BadgeTypes' => [
-        'BadgeTypeID' => 'INT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT',
-        'AvailableFrom' => 'DATE NOT NULL',
-        'AvailableTo' => 'DATE NOT NULL',
-        'Cost' => 'DECIMAL(6,2) NOT NULL',
-        'EventID' => 'INT UNSIGNED NOT NULL',
-        'Name' => 'VARCHAR(50) NOT NULL',
-        'BackgroundImage' => 'VARCHAR(100)',
-    ],
-    'Configuration' => [
-        'Field' => 'VARCHAR(15) NOT NULL PRIMARY KEY',
-        'Value' => 'TEXT NOT NULL',
-    ],
-    'ConComList' => [
-        'ListRecordID' => 'INT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT',
-        'AccountID' => 'INT UNSIGNED NOT NULL', // Taken from NeonCRM Currently
-        'DepartmentID' => 'INT UNSIGNED NOT NULL',
-        'EventID' => 'INT UNSIGNED NOT NULL',
-        'Note' => 'VARCHAR(100)',
-        'PositionID' => 'INT UNSIGNED NOT NULL',
-    ],
-    'ConComPositions' => [
-        'PositionID' => 'INT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT',
-        'Name' => 'VARCHAR(50) NOT NULL',
-    ],
-    'DBPullPage' => [ // Bandaid table to help Neon - To be removed post-neon
-        'RegistrationID' => 'INT UNSIGNED NOT NULL PRIMARY KEY',  // 1:1 mapping of the Registrations Primary Key
-        'Page' => 'INT UNSIGNED NOT NULL',
-    ],
-    'Departments' => [
-        'DepartmentID' => 'INT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT',
-        'Name' => 'VARCHAR(50) NOT NULL',
-        'ParentDepartmentID' => 'INT UNSIGNED NOT NULL',
-    ],
-    'ElegibleVoters' => [
-        'VoterRecordID' => 'INT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT',
-        'AccountID' => 'INT UNSIGNED NOT NULL',
-        'AnnualCycleID' => 'INT UNSIGNED NOT NULL',
-    ],
-    'EMails' => [
-        'EMailAliasID' => 'INT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT',
-        'DepartmentID' => 'INT UNSIGNED NOT NULL',
-        'IsAlias' => 'BOOLEAN',
-        'EMail' => 'VARCHAR(100) NOT NULL',
-    ],
-    'TempEventPage' => [
-        'AccountID' => 'INT UNSIGNED NOT NULL',
-        'PageFound' => 'INT UNSIGNED NOT NULL',
-    ],
-    'Events' => [
-        'EventID' => 'INT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT',
-        'AnnualCycleID' => 'INT UNSIGNED NOT NULL',
-        'DateFrom' => 'DATE NOT NULL',
-        'DateTo' => 'DATE NOT NULL',
-        'EventName' => 'VARCHAR(50) NOT NULL',
-    ],
-    'HourRedemptions' => [
-        'ClaimID' => 'INT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT',
-        'AccountID' => 'INT UNSIGNED NOT NULL',
-        'EventID' => 'INT UNSIGNED NOT NULL',
-        'PrizeID' => 'INT UNSIGNED NOT NULL',
-    ],
-    'MeetingAttendance' => [
-        'AttendanceRecordID' => 'INT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT',
-        'AccountID' => 'INT UNSIGNED NOT NULL',
-        'MeetingID' => 'INT UNSIGNED NOT NULL',
-    ],
-    'OfficialMeetings' => [
-        'MeetingID' => 'INT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT',
-        'Date' => 'DATE NOT NULL',
-        'EventID' => 'INT UNSIGNED NOT NULL',
-        'Name' => 'VARCHAR(50) NOT NULL',
-    ],
-    'Registrations' => [
-        'RegistrationID' => 'INT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT',
-        'AccountID' => 'INT UNSIGNED NOT NULL',
-        'BadgeDependentOnID' => 'INT UNSIGNED',
-        'BadgeName' => 'VARCHAR(100)',
-        'BadgesPickedUp' => 'INT UNSIGNED',
-        'BadgeTypeID' => 'INT UNSIGNED NOT NULL',
-        'EmergencyContact' => 'VARCHAR(300)',
-        'EventID' => 'INT UNSIGNED NOT NULL',
-        'RegisteredByID' => 'INT UNSIGNED NOT NULL',
-        'RegistrationDate' => 'DATETIME NOT NULL',
-    ],
-    'RewardGroup' => [
-        'RewardGroupID' => 'INT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT',
-        'RedeemLimit' => 'INT UNSIGNED',
-    ],
-    'VolunteerHours' => [
-        'HourEntryID' => 'INT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT',
-        'AccountID' => 'INT UNSIGNED NOT NULL',
-        'ActualHours' => 'FLOAT(5,3) NOT NULL',
-        'AuthorizedByID' => 'INT UNSIGNED NOT NULL',
-        'DepartmentID' => 'INT UNSIGNED NOT NULL',
-        'EndDateTime' => 'DATETIME NOT NULL',
-        'EnteredByID' => 'INT UNSIGNED NOT NULL',
-        'EventID' => 'INT UNSIGNED NOT NULL',
-        'TimeModifier' => 'FLOAT(2,1) NOT NULL',
-    ],
-    'VolunteerRewards' => [
-        'PrizeID' => 'INT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT',
-        'Name' => 'VARCHAR(50) NOT NULL',
-        'Promo' => 'BOOLEAN',
-        'RewardGroupID' => 'INT UNSIGNED',
-        'TotalInventory' => 'INT NOT NULL',
-        'Value' => 'DECIMAL(5,2) NOT NULL',
-    ],
-    'Authentication' => [
-        'AccountID' => 'INT UNSIGNED NOT NULL PRIMARY KEY',
-        'Authentication' => 'VARCHAR(110)',
-        'LastLogin' => 'DATETIME',
-        'Expires' => 'DATETIME',
-        'FailedAttempts' => 'INT UNSIGNED NOT NULL DEFAULT 0',
-        'OneTime' => 'VARCHAR(110)',
-        'OneTimeExpires' => 'DATETIME',
-    ],
+    public static $REQUIED_DB_SCHEMA = 2019111900; // Current DB Version - YYYYMMDDvv format (vv=daily counter form 00)
 
-    'EmailLists' => [
-        'EmailListID' => 'INT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT',
-        'Name' => 'VARCHAR(100) NOT NULL',
-        'Description' => 'TEXT NOT NULL',
-        'Code' => 'TEXT',
-    ],
+    public static $DB_tables = [
+        'ActivityLog' => [
+            'LogEntryID' => 'INT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT',
+            'AccountID' => 'INT UNSIGNED NOT NULL', // Use 0 for System AccountID
+            'Function' => 'VARCHAR(100) NOT NULL',
+            'Query' => 'TEXT NOT NULL',
+            'Date' => 'TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP',
+        ],
+        'AnnualCycles' => [ // Bylaw defined "year", used for tracking
+            'AnnualCycleID' => 'INT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT',
+            'DateFrom' => 'DATE NOT NULL',
+            'DateTo' => 'DATE NOT NULL',
+        ],
+        'BadgeTypes' => [
+            'BadgeTypeID' => 'INT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT',
+            'AvailableFrom' => 'DATE NOT NULL',
+            'AvailableTo' => 'DATE NOT NULL',
+            'Cost' => 'DECIMAL(6,2) NOT NULL',
+            'EventID' => 'INT UNSIGNED NOT NULL',
+            'Name' => 'VARCHAR(50) NOT NULL',
+            'BackgroundImage' => 'VARCHAR(100)',
+        ],
+        'Configuration' => [
+            'Field' => 'VARCHAR(15) NOT NULL PRIMARY KEY',
+            'Value' => 'TEXT NOT NULL',
+        ],
+        'ConComList' => [
+            'ListRecordID' => 'INT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT',
+            'AccountID' => 'INT UNSIGNED NOT NULL', // Taken from NeonCRM Currently
+            'DepartmentID' => 'INT UNSIGNED NOT NULL',
+            'EventID' => 'INT UNSIGNED NOT NULL',
+            'Note' => 'VARCHAR(100)',
+            'PositionID' => 'INT UNSIGNED NOT NULL',
+        ],
+        'ConComPositions' => [
+            'PositionID' => 'INT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT',
+            'Name' => 'VARCHAR(50) NOT NULL',
+        ],
+        'DBPullPage' => [ // Bandaid table to help Neon - To be removed post-neon
+            'RegistrationID' => 'INT UNSIGNED NOT NULL PRIMARY KEY',  // 1:1 mapping of the Registrations Primary Key
+            'Page' => 'INT UNSIGNED NOT NULL',
+        ],
+        'DeepLinks' => [
+            'LinkID' => 'INT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT',
+            'AccountID' => 'INT UNSIGNED NOT NULL',
+            'ApproverID' => 'INT UNSIGNED NOT NULL',
+            'ApprovedValue' => 'TEXT NOT NULL',
+            'Auth' => 'VARCHAR(40) NOT NULL',
+            'Date' => 'TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP',
+            'Description' => 'VARCHAR(100) NOT NULL',
+            'Type' => 'VARCHAR(10) NOT NULL',
+        ],
+        'Departments' => [
+            'DepartmentID' => 'INT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT',
+            'Name' => 'VARCHAR(50) NOT NULL',
+            'ParentDepartmentID' => 'INT UNSIGNED NOT NULL',
+        ],
+        'ElegibleVoters' => [
+            'VoterRecordID' => 'INT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT',
+            'AccountID' => 'INT UNSIGNED NOT NULL',
+            'AnnualCycleID' => 'INT UNSIGNED NOT NULL',
+        ],
+        'EMails' => [
+            'EMailAliasID' => 'INT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT',
+            'DepartmentID' => 'INT UNSIGNED NOT NULL',
+            'IsAlias' => 'BOOLEAN',
+            'EMail' => 'VARCHAR(100) NOT NULL',
+        ],
+        'TempEventPage' => [
+            'AccountID' => 'INT UNSIGNED NOT NULL',
+            'PageFound' => 'INT UNSIGNED NOT NULL',
+        ],
+        'Events' => [
+            'EventID' => 'INT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT',
+            'AnnualCycleID' => 'INT UNSIGNED NOT NULL',
+            'DateFrom' => 'DATE NOT NULL',
+            'DateTo' => 'DATE NOT NULL',
+            'EventName' => 'VARCHAR(50) NOT NULL',
+        ],
+        'HourRedemptions' => [
+            'ClaimID' => 'INT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT',
+            'AccountID' => 'INT UNSIGNED NOT NULL',
+            'EventID' => 'INT UNSIGNED NOT NULL',
+            'PrizeID' => 'INT UNSIGNED NOT NULL',
+        ],
+        'MeetingAttendance' => [
+            'AttendanceRecordID' => 'INT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT',
+            'AccountID' => 'INT UNSIGNED NOT NULL',
+            'MeetingID' => 'INT UNSIGNED NOT NULL',
+        ],
+        'OfficialMeetings' => [
+            'MeetingID' => 'INT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT',
+            'Date' => 'DATE NOT NULL',
+            'EventID' => 'INT UNSIGNED NOT NULL',
+            'Name' => 'VARCHAR(50) NOT NULL',
+        ],
+        'Registrations' => [
+            'RegistrationID' => 'INT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT',
+            'AccountID' => 'INT UNSIGNED NOT NULL',
+            'BadgeDependentOnID' => 'INT UNSIGNED',
+            'BadgeName' => 'VARCHAR(100)',
+            'BadgesPickedUp' => 'INT UNSIGNED',
+            'BadgeTypeID' => 'INT UNSIGNED NOT NULL',
+            'EmergencyContact' => 'VARCHAR(300)',
+            'EventID' => 'INT UNSIGNED NOT NULL',
+            'RegisteredByID' => 'INT UNSIGNED NOT NULL',
+            'RegistrationDate' => 'DATETIME NOT NULL',
+        ],
+        'RewardGroup' => [
+            'RewardGroupID' => 'INT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT',
+            'RedeemLimit' => 'INT UNSIGNED',
+        ],
+        'VolunteerHours' => [
+            'HourEntryID' => 'INT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT',
+            'AccountID' => 'INT UNSIGNED NOT NULL',
+            'ActualHours' => 'FLOAT(5,3) NOT NULL',
+            'AuthorizedByID' => 'INT UNSIGNED NOT NULL',
+            'DepartmentID' => 'INT UNSIGNED NOT NULL',
+            'EndDateTime' => 'DATETIME NOT NULL',
+            'EnteredByID' => 'INT UNSIGNED NOT NULL',
+            'EventID' => 'INT UNSIGNED NOT NULL',
+            'TimeModifier' => 'FLOAT(2,1) NOT NULL',
+        ],
+        'VolunteerRewards' => [
+            'PrizeID' => 'INT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT',
+            'Name' => 'VARCHAR(50) NOT NULL',
+            'Promo' => 'BOOLEAN',
+            'RewardGroupID' => 'INT UNSIGNED',
+            'TotalInventory' => 'INT NOT NULL',
+            'Value' => 'DECIMAL(5,2) NOT NULL',
+        ],
+        'Authentication' => [
+            'AccountID' => 'INT UNSIGNED NOT NULL PRIMARY KEY',
+            'Authentication' => 'VARCHAR(110)',
+            'LastLogin' => 'DATETIME',
+            'Expires' => 'DATETIME',
+            'FailedAttempts' => 'INT UNSIGNED NOT NULL DEFAULT 0',
+            'OneTime' => 'VARCHAR(110)',
+            'OneTimeExpires' => 'DATETIME',
+        ],
+    
+        'EmailLists' => [
+            'EmailListID' => 'INT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT',
+            'Name' => 'VARCHAR(100) NOT NULL',
+            'Description' => 'TEXT NOT NULL',
+            'Code' => 'TEXT',
+        ],
+    
+        'EmailListAccess' => [
+            'DepartmentID' => 'INT UNSIGNED NOT NULL',
+            'PositionID' => 'INT UNSIGNED NOT NULL',
+            'EmailListID' => 'INT UNSIGNED NOT NULL',
+            'EditList' => 'BOOLEAN NOT NULL',
+            'ChangeAccess' => 'BOOLEAN NOT NULL',
+        ],
+    
+        'ConComPermissions' => [
+            'PermissionID' => 'INT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT',
+            'Position' => 'VARCHAR(100) NOT NULL',
+            'Permission' => 'VARCHAR(100) NOT NULL',
+            'Note' => 'TEXT'
+        ]
+    ];
+    
+    
+    public static $DB_foreignKeys = [
+        'BadgeTypes' => [
+            'EventID' => 'Events (EventID) ON DELETE RESTRICT ON UPDATE CASCADE',
+        ],
+        'ConComList' => [
+            'DepartmentID' => 'Departments (DepartmentID) ON DELETE RESTRICT ON UPDATE CASCADE',
+            'EventID' => 'Events (EventID) ON DELETE RESTRICT ON UPDATE CASCADE',
+            'PositionID' => 'ConComPositions (PositionID) ON DELETE RESTRICT ON UPDATE CASCADE',
+        ],
+        'DBPullPage' => [
+            'RegistrationID' => 'Registrations (RegistrationID) ON DELETE RESTRICT ON UPDATE CASCADE',
+        ],
+        'Departments' => [
+            'ParentDepartmentID' => 'Departments (DepartmentID) ON DELETE RESTRICT ON UPDATE CASCADE',
+        ],
+        'ElegibleVoters' => [
+            'AnnualCycleID' => 'AnnualCycles (AnnualCycleID) ON DELETE RESTRICT ON UPDATE CASCADE',
+        ],
+        'EMails' => [
+            'DepartmentID' => 'Departments (DepartmentID) ON DELETE RESTRICT ON UPDATE CASCADE',
+        ],
+        'Events' => [
+            'AnnualCycleID' => 'AnnualCycles (AnnualCycleID) ON DELETE RESTRICT ON UPDATE CASCADE',
+        ],
+        'HourRedemptions' => [
+            'EventID' => 'Events (EventID) ON DELETE RESTRICT ON UPDATE CASCADE',
+            'PrizeID' => 'VolunteerRewards (PrizeID) ON DELETE RESTRICT ON UPDATE CASCADE',
+        ],
+        'MeetingAttendance' => [
+            'MeetingID' => 'OfficialMeetings (MeetingID) ON DELETE RESTRICT ON UPDATE CASCADE',
+        ],
+        'OfficialMeetings' => [
+            'EventID' => 'Events (EventID) ON DELETE RESTRICT ON UPDATE CASCADE',
+        ],
+        'Registrations' => [
+            'BadgeDependentOnID' => 'Registrations (RegistrationID) ON DELETE RESTRICT ON UPDATE CASCADE',
+            'BadgeTypeID' => 'BadgeTypes (BadgeTypeID) ON DELETE RESTRICT ON UPDATE CASCADE',
+            'EventID' => 'Events (EventID) ON DELETE RESTRICT ON UPDATE CASCADE',
+        ],
+        'VolunteerHours' => [
+            'DepartmentID' => 'Departments (DepartmentID) ON DELETE RESTRICT ON UPDATE CASCADE',
+            'EventID' => 'Events (EventID) ON DELETE RESTRICT ON UPDATE CASCADE',
+        ],
+        'VolunteerRewards' => [
+            'RewardGroupID' => 'RewardGroup (RewardGroupID) ON DELETE RESTRICT ON UPDATE CASCADE',
+        ],
+    ];
 
-    'EmailListAccess' => [
-        'DepartmentID' => 'INT UNSIGNED NOT NULL',
-        'PositionID' => 'INT UNSIGNED NOT NULL',
-        'EmailListID' => 'INT UNSIGNED NOT NULL',
-        'EditList' => 'BOOLEAN NOT NULL',
-        'ChangeAccess' => 'BOOLEAN NOT NULL',
-    ],
 
-    'ConComPermissions' => [
-        'PermissionID' => 'INT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT',
-        'Position' => 'VARCHAR(100) NOT NULL',
-        'Permission' => 'VARCHAR(100) NOT NULL',
-        'Note' => 'TEXT'
-    ]
-  ];
-
-  public static $DB_foreignKeys = [
-    'BadgeTypes' => [
-        'EventID' => 'Events (EventID) ON DELETE RESTRICT ON UPDATE CASCADE',
-    ],
-    'ConComList' => [
-        'DepartmentID' => 'Departments (DepartmentID) ON DELETE RESTRICT ON UPDATE CASCADE',
-        'EventID' => 'Events (EventID) ON DELETE RESTRICT ON UPDATE CASCADE',
-        'PositionID' => 'ConComPositions (PositionID) ON DELETE RESTRICT ON UPDATE CASCADE',
-    ],
-    'DBPullPage' => [
-        'RegistrationID' => 'Registrations (RegistrationID) ON DELETE RESTRICT ON UPDATE CASCADE',
-    ],
-    'Departments' => [
-        'ParentDepartmentID' => 'Departments (DepartmentID) ON DELETE RESTRICT ON UPDATE CASCADE',
-    ],
-    'ElegibleVoters' => [
-        'AnnualCycleID' => 'AnnualCycles (AnnualCycleID) ON DELETE RESTRICT ON UPDATE CASCADE',
-    ],
-    'EMails' => [
-        'DepartmentID' => 'Departments (DepartmentID) ON DELETE RESTRICT ON UPDATE CASCADE',
-    ],
-    'Events' => [
-        'AnnualCycleID' => 'AnnualCycles (AnnualCycleID) ON DELETE RESTRICT ON UPDATE CASCADE',
-    ],
-    'HourRedemptions' => [
-        'EventID' => 'Events (EventID) ON DELETE RESTRICT ON UPDATE CASCADE',
-        'PrizeID' => 'VolunteerRewards (PrizeID) ON DELETE RESTRICT ON UPDATE CASCADE',
-    ],
-    'MeetingAttendance' => [
-        'MeetingID' => 'OfficialMeetings (MeetingID) ON DELETE RESTRICT ON UPDATE CASCADE',
-    ],
-    'OfficialMeetings' => [
-        'EventID' => 'Events (EventID) ON DELETE RESTRICT ON UPDATE CASCADE',
-    ],
-    'Registrations' => [
-        'BadgeDependentOnID' => 'Registrations (RegistrationID) ON DELETE RESTRICT ON UPDATE CASCADE',
-        'BadgeTypeID' => 'BadgeTypes (BadgeTypeID) ON DELETE RESTRICT ON UPDATE CASCADE',
-        'EventID' => 'Events (EventID) ON DELETE RESTRICT ON UPDATE CASCADE',
-    ],
-    'VolunteerHours' => [
-        'DepartmentID' => 'Departments (DepartmentID) ON DELETE RESTRICT ON UPDATE CASCADE',
-        'EventID' => 'Events (EventID) ON DELETE RESTRICT ON UPDATE CASCADE',
-    ],
-    'VolunteerRewards' => [
-        'RewardGroupID' => 'RewardGroup (RewardGroupID) ON DELETE RESTRICT ON UPDATE CASCADE',
-    ],
-  ];
+    public static $DB_primaryKeys = [
+        'TempEventPage' => ['AccountID', 'PageFound'],
+        'EmailListAccess' => ['DepartmentID', 'PositionID', 'EmailListID'],
+    ];
 
 
-  public static $DB_primaryKeys = [
-    'TempEventPage' => ['AccountID', 'PageFound'],
-    'EmailListAccess' => ['DepartmentID', 'PositionID', 'EmailListID'],
-  ];
+    public static $DB_index = [
+        'ConComPermissions' => ['Permission'],
+    ];
 
-
-  public static $DB_index = [
-    'ConComPermissions' => ['Permission'],
-  ];
 }
+
 ?>

--- a/functions/session.inc
+++ b/functions/session.inc
@@ -72,14 +72,15 @@ function buildSessionData($accountId)
 }
 
 
-// Support DeepLinks by testing
+// Support DeepLinks for function responses
 function validateDeepLink($deepLinkId)
 {
     if ($deepLinkId == $GLOBALS['DUMPSECURE']) {
         return(true);
     } else {
-    // Do search for DeepLink Info based on Function
-    // Search customfields where pending function equals DeepLinkId - Should never return more than one
+        $sql = "SELECT * from `DeepLinks` where LinkID = $deepLinkId";
+        $result = DB::run($sql);
+        return($result->fetch());
     }
 
 }

--- a/modules/concom/functions/ATTENDANCE.inc
+++ b/modules/concom/functions/ATTENDANCE.inc
@@ -1,0 +1,44 @@
+<?php
+
+require_once(__DIR__.'/../functions/concom.inc');
+
+
+function update_meeting_attendance($meeting, $accountId)
+{
+    $sql = "INSERT INTO `MeetingAttendance` (AccountID, MeetingID) VALUES ($accountId, $meeting);";
+    DB::run($sql);
+
+}
+
+
+function check_meeting_attendance($meeting)
+{
+    $sql = "SELECT * FROM `MeetingAttendance` WHERE AccountID = ".$_SESSION['accountId']." AND MeetingID = $meeting;";
+    $result = \DB::run($sql);
+    $value = $result->fetch();
+    return ($value !== false);
+
+}
+
+
+function check_meeting_pastrequest($meeting)
+{
+    $sql = "SELECT * FROM `DeepLinks` WHERE AccountID = ".$_SESSION['accountId']." AND Type = 'pastcred' AND ApprovedValue = $meeting;";
+    $result = \DB::run($sql);
+    $value = $result->fetch();
+    return ($value !== false);
+
+}
+
+
+function request_past_attendance($meeting)
+{
+    $user = lookup_user_by_id($_SESSION['accountId']);
+    $aprid = 3218; ##==##
+    $auth = bin2hex(random_bytes(20));
+    $desc = $user['users'][0]['First Name']." ".$user['users'][0]['Last Name']." has claimed to be at meeting ID: ".$meeting;
+    $type = "pastcred";
+    $sql = "INSERT INTO `DeepLinks` (AccountID, ApproverID, ApprovedValue, Auth, Description, Type) VALUES (".$_SESSION['accountId'].", $aprid, $meeting, '$auth', '$desc', '$type');";
+    DB::run($sql);
+
+}

--- a/modules/concom/functions/concom.inc
+++ b/modules/concom/functions/concom.inc
@@ -9,6 +9,7 @@ require_once(__DIR__.'/VOLUNTEERS.inc');
 require_once(__DIR__.'/POSITION.inc');
 require_once(__DIR__.'/REGISTRATION.inc');
 require_once(__DIR__.'/LIST.inc');
+require_once(__DIR__.'/ATTENDANCE.inc');
 
 
 function getDivision($dep)
@@ -441,17 +442,6 @@ SQL;
         $value = $result->fetch();
     }
     return $years;
-
-}
-
-
-function check_meeting_attendance($meeting)
-{
-    $aid = $_SESSION['accountId'];
-    $sql = "SELECT * FROM `MeetingAttendance` WHERE AccountID = $aid AND MeetingID = $meeting;";
-    $result = \DB::run($sql);
-    $value = $result->fetch();
-    return ($value !== false);
 
 }
 

--- a/modules/concom/pages/panes.inc
+++ b/modules/concom/pages/panes.inc
@@ -105,7 +105,17 @@ function meetings()
                 if ($nowDate == $checkDate) {
                     echo "<td class='CONCOM-checkin-now'><a href='index.php?Function=concom/signin&meeting=".$value['MeetingID']."'>Sign In Now!</a>";
                 } else {
-                    echo "<td>Not Checked In";
+                    echo "<td>";
+                    $checkPending = check_meeting_pastrequest($value['MeetingID']);
+
+                    if ($checkPending) {
+                        echo "Not Checked In - Attendance request pending";
+                    } else {
+                        echo "<form action='index.php?Function=concom/pastcredit&meeting=".$value['MeetingID']."' method='post' name='butiwasthere' id='butiwasthere'>";
+                        echo "<input type='hidden' name='meeting' value='".$value['MeetingID']."'>";
+                        echo "Not Checked In - <button class='UI-orangebutton'>But I attended!</button>";
+                        echo "</form>";
+                    }
                 }
             }
             echo "</td></tr>\n";

--- a/modules/concom/pastcredit/pages/pre.inc
+++ b/modules/concom/pastcredit/pages/pre.inc
@@ -5,7 +5,7 @@
 
 require_once(__DIR__."/../../functions/ATTENDANCE.inc");
 
-// Sign in this user for today's meeting
+// Request Past Attendance Credit form Divisional Directors
 
 if (!empty($_REQUEST['meeting'])) {
     $arguments = [
@@ -14,7 +14,7 @@ if (!empty($_REQUEST['meeting'])) {
 
     $updateData = filter_input_array(INPUT_GET, $arguments);
     if (isset($updateData['meeting'])) {
-        update_meeting_attendance($updateData['meeting'], $_SESSION['accountId']);
+        request_past_attendance($updateData['meeting']);
     }
 }
 


### PR DESCRIPTION
Updates the deeplinks process and allows for requesting attendance at past meetings.

NOTE:  This makes a record of the request ONLY.  It does not yet send the request for approval as, I am uncomfortable with making that change at the same time.

This patch DOES through PHP notices about missing index, as the name lookup seems to fail, but I need that for the "part 2" of this.

Please do a run of this in your working environment of both a past meeting AND signin-today meeting so we know it's not going to break things in prod