### PR TITLE
Add a ConCom Membership report

### DIFF
--- a/modules/concom/functions/concom.inc
+++ b/modules/concom/functions/concom.inc
@@ -1080,3 +1080,69 @@ SQL;
     return $result;
 
 }
+
+
+function concom_report($event = null)
+{
+    if ($event === null) {
+        $event = \current_eventID();
+    }
+
+    return <<<SQL
+        SELECT
+            AccountID,
+            (
+            SELECT
+                `Name`
+            FROM
+                `Departments`
+            WHERE
+                `DepartmentID` = a.`DepartmentID`
+        ) AS Department,
+        (
+            SELECT
+                `Name`
+            FROM
+                `Departments`
+            WHERE
+                `DepartmentID` =(
+                SELECT
+                    `ParentDepartmentID`
+                FROM
+                    `Departments`
+                WHERE
+                    `DepartmentID` = a.`DepartmentID`
+            )
+        ) AS Division,
+        (
+            SELECT
+                `EventName`
+            FROM
+                `Events`
+            WHERE
+                `EventID` = a.`EventID`
+        ) AS EVENT,
+        (
+            SELECT
+                `Name`
+            FROM
+                `ConComPositions`
+            WHERE
+                `PositionID` = a.`PositionID`
+        ) AS POSITION,
+        (
+            SELECT
+                `Email`
+            FROM
+                `Members`
+            WHERE
+                `AccountID` = a.`AccountID`
+        ) AS Email,
+        Note
+        FROM
+            `ConComList` AS a
+        WHERE
+            `EventID` = '$event'
+SQL;
+
+}

--- a/modules/concom/pages/menubar.inc
+++ b/modules/concom/pages/menubar.inc
@@ -19,3 +19,14 @@ if (\ciab\RBAC::havePermission("site.concom.structure")) {
          'text' => 'ConCom Structure',
          'responsive' => true);
 }
+
+
+if (\ciab\RBAC::havePermission("concom.reports")) {
+    $report_menus[] = array('base style' => 'UI-yellow',
+     'selected style' => 'event-color-primary',
+     'function' => 'concom/report',
+     'title' => 'ConCom Membership',
+     'i class' => 'fas fa-phone',
+     'text' => 'ConCom Membership',
+     'responsive' => true);
+}

--- a/modules/concom/report/pages/body.inc
+++ b/modules/concom/report/pages/body.inc
@@ -1,0 +1,35 @@
+<?php
+?>
+<script>
+    var sidebarMainDiv = 'main_content';
+    reportGenerationSidebar.options({
+        target: 'concom/report',
+        reportDisplay: '#report_display'
+    });
+</script>
+
+<div id="page" class="UI-continer">
+  <div id="main_content" class="UI-maincontent">
+    <div class='UI-event-sectionbar'>
+      <span>ConCom Reports</span>
+    </div>
+&nbsp;
+    <div class="UI-rest UI-center">
+      <div class='VOL-admin'>
+        <div id='volunteer_admin_bar' class='VOL-admin-bar'>
+          <button id='gen_der_csv' class='UI-eventbutton' onclick='reportGenerationSidebar.open();'>Generate CSV Report</button>
+        </div>
+      </div>
+       &nbsp;
+      <div class='UI-continer UI-padding'>
+        <div class='UI-event-sectionbar'>
+          <span>Report Data</span>
+          </div>
+        <div id='report_display'>
+        </div>
+         &nbsp;
+      </div>
+      &nbsp;
+    </div>
+  </div>
+</div>

--- a/modules/concom/report/pages/head.inc
+++ b/modules/concom/report/pages/head.inc
@@ -1,0 +1,7 @@
+<?php
+?>
+<script src="sitesupport/sidebar.js"></script>
+<script src="sitesupport/common.js"></script>
+<script src="sitesupport/reportGeneration.js"></script>
+<script src="sitesupport/d3.v5.min.js"></script>
+<script src="sitesupport/csv.js"></script>

--- a/modules/concom/report/pages/pre.inc
+++ b/modules/concom/report/pages/pre.inc
@@ -1,0 +1,29 @@
+<?php
+
+/*.
+    require_module 'standard';
+.*/
+
+require_once($BACKEND."/RBAC.inc");
+
+if (!\ciab\RBAC::havePermission("concom.reports")) {
+    goSite();
+}
+
+require_once __DIR__.'/../../functions/concom.inc';
+require_once($FUNCTIONDIR."/reports.inc");
+
+$reports = [];
+
+$sql = 'SELECT * FROM `Events`';
+$result = \DB::Run($sql);
+$value = $result->fetch();
+while ($value !== false) {
+    $reports['ConCom Membership for '.$value['EventName']] = [
+    'concom_report',
+    $value['EventID']
+    ];
+    $value = $result->fetch();
+}
+
+handle_report_request($reports);

--- a/sitesupport/permissions.js
+++ b/sitesupport/permissions.js
@@ -26,6 +26,10 @@ var PERMISSIONS = [
     description:'Able to upload and change site graphical assets'
   },
   {
+    permission:'concom.reports',
+    description:'Generate a CSV report of the ConCom Membership'
+  },
+  {
     permission:'concom.view',
     description:'View the ConCom list'
   },


### PR DESCRIPTION
This ability is added to a department using the `concom.reports` RBAC
entry. By default this is not added to any departments so only ADMIN
users have initial access until it the permission is added to a
department.