### PR TITLE
Allow modules to specify database schema

### DIFF
--- a/data/database-schema.php
+++ b/data/database-schema.php
@@ -89,12 +89,6 @@ class SCHEMA
             'DateTo' => 'DATE NOT NULL',
             'EventName' => 'VARCHAR(50) NOT NULL',
         ],
-        'HourRedemptions' => [
-            'ClaimID' => 'INT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT',
-            'AccountID' => 'INT UNSIGNED NOT NULL',
-            'EventID' => 'INT UNSIGNED NOT NULL',
-            'PrizeID' => 'INT UNSIGNED NOT NULL',
-        ],
         'MeetingAttendance' => [
             'AttendanceRecordID' => 'INT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT',
             'AccountID' => 'INT UNSIGNED NOT NULL',
@@ -117,29 +111,6 @@ class SCHEMA
             'EventID' => 'INT UNSIGNED NOT NULL',
             'RegisteredByID' => 'INT UNSIGNED NOT NULL',
             'RegistrationDate' => 'DATETIME NOT NULL',
-        ],
-        'RewardGroup' => [
-            'RewardGroupID' => 'INT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT',
-            'RedeemLimit' => 'INT UNSIGNED',
-        ],
-        'VolunteerHours' => [
-            'HourEntryID' => 'INT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT',
-            'AccountID' => 'INT UNSIGNED NOT NULL',
-            'ActualHours' => 'FLOAT(5,3) NOT NULL',
-            'AuthorizedByID' => 'INT UNSIGNED NOT NULL',
-            'DepartmentID' => 'INT UNSIGNED NOT NULL',
-            'EndDateTime' => 'DATETIME NOT NULL',
-            'EnteredByID' => 'INT UNSIGNED NOT NULL',
-            'EventID' => 'INT UNSIGNED NOT NULL',
-            'TimeModifier' => 'FLOAT(2,1) NOT NULL',
-        ],
-        'VolunteerRewards' => [
-            'PrizeID' => 'INT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT',
-            'Name' => 'VARCHAR(50) NOT NULL',
-            'Promo' => 'BOOLEAN',
-            'RewardGroupID' => 'INT UNSIGNED',
-            'TotalInventory' => 'INT NOT NULL',
-            'Value' => 'DECIMAL(5,2) NOT NULL',
         ],
         'Authentication' => [
             'AccountID' => 'INT UNSIGNED NOT NULL PRIMARY KEY',
@@ -180,38 +151,11 @@ class SCHEMA
             'PreferredLastName' => 'VARCHAR(50)',
             'DisplayPhone' => 'BOOLEAN',
         ],
-        'EmailLists' => [
-            'EmailListID' => 'INT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT',
-            'Name' => 'VARCHAR(100) NOT NULL',
-            'Description' => 'TEXT NOT NULL',
-            'Code' => 'TEXT',
-        ],
-        'EmailListAccess' => [
-            'DepartmentID' => 'INT UNSIGNED NOT NULL',
-            'PositionID' => 'INT UNSIGNED NOT NULL',
-            'EmailListID' => 'INT UNSIGNED NOT NULL',
-            'EditList' => 'BOOLEAN NOT NULL',
-            'ChangeAccess' => 'BOOLEAN NOT NULL',
-        ],
         'ConComPermissions' => [
             'PermissionID' => 'INT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT',
             'Position' => 'VARCHAR(100) NOT NULL',
             'Permission' => 'VARCHAR(100) NOT NULL',
             'Note' => 'TEXT'
-        ],
-        'Deadlines' => [
-            'DeadlineID' => 'INT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT',
-            'DepartmentID' => 'INT UNSIGNED NOT NULL',
-            'Deadline' => 'DATE NOT NULL',
-            'Note' => 'TEXT NOT NULL'
-        ],
-        'Announcements' => [
-            'AnnouncementID' => 'INT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT',
-            'DepartmentID' => 'INT UNSIGNED NOT NULL',
-            'PostedBy' => 'INT UNSIGNED NOT NULL',
-            'PostedOn' => 'DATE NOT NULL',
-            'Scope' => 'INT UNSIGNED NOT NULL',
-            'Text' => 'TEXT NOT NULL'
         ]
 
     ];
@@ -255,25 +199,12 @@ class SCHEMA
             'BadgeTypeID' => 'BadgeTypes (BadgeTypeID) ON DELETE RESTRICT ON UPDATE CASCADE',
             'EventID' => 'Events (EventID) ON DELETE RESTRICT ON UPDATE CASCADE',
         ],
-        'VolunteerHours' => [
-            'DepartmentID' => 'Departments (DepartmentID) ON DELETE RESTRICT ON UPDATE CASCADE',
-            'EventID' => 'Events (EventID) ON DELETE RESTRICT ON UPDATE CASCADE',
-        ],
-        'VolunteerRewards' => [
-            'RewardGroupID' => 'RewardGroup (RewardGroupID) ON DELETE RESTRICT ON UPDATE CASCADE',
-        ],
-        'Deadlines' => [
-            'DepartmentID' => 'Departments (DepartmentID) ON DELETE RESTRICT ON UPDATE CASCADE',
-        ],
-        'Announcements' => [
-            'DepartmentID' => 'Departments (DepartmentID) ON DELETE RESTRICT ON UPDATE CASCADE',
-            'PostedBy' => 'Members (AccountID) ON DELETE RESTRICT ON UPDATE CASCADE',
-        ],
+
     ];
 
     public static $DB_primaryKeys = [
-        'TempEventPage' => ['AccountID', 'PageFound'],
-        'EmailListAccess' => ['DepartmentID', 'PositionID', 'EmailListID'],
+        'TempEventPage' => ['AccountID', 'PageFound']
+
     ];
 
     public static $DB_index = [

--- a/functions/database.inc
+++ b/functions/database.inc
@@ -2,6 +2,7 @@
 
 /*.
     require_module 'standard';
+    require_module 'json';
 .*/
 
 // Currently, this database class is set for the MySQL PDO filter/backend. Future version will expand it to be agnostic
@@ -10,8 +11,20 @@ require_once(__DIR__.'/locations.inc');
 require_once($BACKEND.'/'.$_ENV['DB_BACKEND']); // MyPDO Definition used
 require_once($BASEDIR.'/data/database-schema.php');
 
+
+$MODULE_TABLES = array();
+$MODULE_FOREIGNKEYS = array();
+$MODULE_PRIMARYKEYS = array();
+$MODULE_INDEX = array();
+
+
 class DB
 {
+
+    /**
+     * @var array
+     */
+    private $schema;
 
 
     private static function verifyDB()
@@ -81,7 +94,7 @@ SQL;
     }
 
 
-    private static function buildMissingTables()
+    private function buildMissingTables()
     {
         // This function cannot call the run function as we don't know if the activitylog table is created
         // Besides, this is maintenance, not user log tracking
@@ -96,7 +109,7 @@ SQL;
             }
         }
         // Verify every table we need exists, if not, create.
-        foreach (SCHEMA::$DB_tables as $table => $fields) {
+        foreach ($this->schema['tables'] as $table => $fields) {
             if (in_array($table, $arr)) {
                 // Table exists
                 // Capture a list of fields already in the table
@@ -134,7 +147,7 @@ SQL;
         }
 
         //Verify primary keys
-        foreach (SCHEMA::$DB_primaryKeys as $table => $keys) {
+        foreach ($this->schema['primaryKeys'] as $table => $keys) {
             $query = "SHOW KEYS FROM `$table` WHERE Key_name = 'PRIMARY';";
             $result = MyPDO::instance()->query($query);
             $value = $result->fetch();
@@ -153,7 +166,7 @@ SQL;
             $arr[] = $value['TABLE_NAME'].":".$value['COLUMN_NAME'];
         }
         // Verify every foreign key we need exists, if not, create.
-        foreach (SCHEMA::$DB_foreignKeys as $table => $fields) {
+        foreach ($this->schema['foreignKeys'] as $table => $fields) {
             foreach ($fields as $column => $referto) {
                 $lookfor = $table.":".$column;
                 if (!in_array($lookfor, $arr)) {
@@ -165,7 +178,7 @@ SQL;
         }
 
         //  Create index
-        foreach (SCHEMA::$DB_index as $table => $keys) {
+        foreach ($this->schema['index'] as $table => $keys) {
             $build = "SHOW INDEX FROM `".$table."`;";
             $result = mypdo::instance()->query($build);
             $arr = [];
@@ -184,12 +197,50 @@ SQL;
     }
 
 
+    public function loadModules()
+    {
+        global $MODULE_TABLES, $MODULESDIR;
+
+        if ($this->loaded) {
+            return;
+        }
+        try {
+            $modules = scandir($MODULESDIR);
+            foreach ($modules as $key => $value) {
+                if (!in_array($value, array(".", ".."))) {
+                    if (is_dir($MODULESDIR.DIRECTORY_SEPARATOR.$value)) {
+                        if (is_file($MODULESDIR.DIRECTORY_SEPARATOR.$value.DIRECTORY_SEPARATOR.'database-schema.inc')) {
+                            require_once($MODULESDIR.DIRECTORY_SEPARATOR.$value.DIRECTORY_SEPARATOR.'database-schema.inc');
+                        }
+                    }
+                }
+            }
+        } catch (RuntimeException $e) {
+            error_log("ERROR!!! Database Schema import failed: ".$e);
+        }
+
+        $this->schema['tables'] = array_merge($this->schema['tables'], $MODULE_TABLES);
+        $this->schema['foreignKeys'] = array_merge($this->schema['foreignKeys'], $MODULE_FOREIGNKEYS);
+        $this->schema['primaryKeys'] = array_merge($this->schema['primaryKeys'], $MODULE_PRIMARYKEYS);
+        $this->schema['index'] = array_merge($this->schema['index'], $MODULE_INDEX);
+        $this->loaded = true;
+
+    }
+
+
     public function __construct()
     {
+        $this->schema = array();
+        $this->schema['tables'] = SCHEMA::$DB_tables;
+        $this->schema['foreignKeys'] = SCHEMA::$DB_foreignKeys;
+        $this->schema['primaryKeys'] = SCHEMA::$DB_primaryKeys;
+        $this->schema['index'] = SCHEMA::$DB_index;
+        $this->loadModules();
         $oldMD5 = DB::getRecordedDBSchemaMD5();
-        $currentMD5 = md5_file($GLOBALS['BASEDIR'].'/data/database-schema.php');
+        $currentMD5 = md5(json_encode($this->schema));
+
         if ($oldMD5 != $currentMD5) {
-            DB::buildMissingTables();
+            $this->buildMissingTables();
             $sql = <<<SQL
                 REPLACE INTO Configuration
                     (`Value`, `Field`)

--- a/modules/announcements/database-schema.inc
+++ b/modules/announcements/database-schema.inc
@@ -1,0 +1,30 @@
+<?php
+
+/*.
+    require_module 'standard';
+.*/
+
+namespace announcements;
+
+$DB_tables = [
+'Announcements' => [
+'AnnouncementID' => 'INT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT',
+'DepartmentID' => 'INT UNSIGNED NOT NULL',
+'PostedBy' => 'INT UNSIGNED NOT NULL',
+'PostedOn' => 'DATE NOT NULL',
+'Scope' => 'INT UNSIGNED NOT NULL',
+'Text' => 'TEXT NOT NULL'
+    ]
+
+];
+
+$DB_foreignKeys = [
+'Announcements' => [
+'DepartmentID' => 'Departments (DepartmentID) ON DELETE RESTRICT ON UPDATE CASCADE',
+'PostedBy' => 'Members (AccountID) ON DELETE RESTRICT ON UPDATE CASCADE',
+    ]
+
+];
+
+$MODULE_TABLES = array_merge($MODULE_TABLES, $DB_tables);
+$MODULE_FOREIGNKEYS = array_merge($MODULE_FOREIGNKEYS, $DB_foreignKeys);

--- a/modules/deadlines/database-schema.inc
+++ b/modules/deadlines/database-schema.inc
@@ -1,0 +1,27 @@
+<?php
+
+/*.
+    require_module 'standard';
+.*/
+
+namespace deadlines;
+
+$DB_tables = [
+'Deadlines' => [
+'DeadlineID' => 'INT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT',
+'DepartmentID' => 'INT UNSIGNED NOT NULL',
+'Deadline' => 'DATE NOT NULL',
+'Note' => 'TEXT NOT NULL'
+    ]
+
+];
+
+$DB_foreignKeys = [
+'Deadlines' => [
+'DepartmentID' => 'Departments (DepartmentID) ON DELETE RESTRICT ON UPDATE CASCADE',
+    ]
+
+];
+
+$MODULE_TABLES = array_merge($MODULE_TABLES, $DB_tables);
+$MODULE_FOREIGNKEYS = array_merge($MODULE_FOREIGNKEYS, $DB_foreignKeys);

--- a/modules/emailer/database-schema.inc
+++ b/modules/emailer/database-schema.inc
@@ -1,0 +1,32 @@
+<?php
+
+/*.
+    require_module 'standard';
+.*/
+
+namespace emailer;
+
+$DB_tables = [
+'EmailLists' => [
+'EmailListID' => 'INT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT',
+'Name' => 'VARCHAR(100) NOT NULL',
+'Description' => 'TEXT NOT NULL',
+'Code' => 'TEXT',
+],
+'EmailListAccess' => [
+'DepartmentID' => 'INT UNSIGNED NOT NULL',
+'PositionID' => 'INT UNSIGNED NOT NULL',
+'EmailListID' => 'INT UNSIGNED NOT NULL',
+'EditList' => 'BOOLEAN NOT NULL',
+'ChangeAccess' => 'BOOLEAN NOT NULL',
+]
+
+];
+
+$DB_primaryKeys = [
+'EmailListAccess' => ['DepartmentID', 'PositionID', 'EmailListID']
+
+];
+
+$MODULE_TABLES = array_merge($MODULE_TABLES, $DB_tables);
+$MODULE_PRIMARYKEYS = array_merge($MODULE_PRIMARYKEYS, $DB_primaryKeys);

--- a/modules/volunteers/database-schema.inc
+++ b/modules/volunteers/database-schema.inc
@@ -1,0 +1,54 @@
+<?php
+
+/*.
+    require_module 'standard';
+.*/
+
+namespace volunteers;
+
+$DB_tables = [
+'HourRedemptions' => [
+'ClaimID' => 'INT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT',
+'AccountID' => 'INT UNSIGNED NOT NULL',
+'EventID' => 'INT UNSIGNED NOT NULL',
+'PrizeID' => 'INT UNSIGNED NOT NULL',
+    ],
+'RewardGroup' => [
+'RewardGroupID' => 'INT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT',
+'RedeemLimit' => 'INT UNSIGNED',
+    ],
+'VolunteerHours' => [
+'HourEntryID' => 'INT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT',
+'AccountID' => 'INT UNSIGNED NOT NULL',
+'ActualHours' => 'FLOAT(5,3) NOT NULL',
+'AuthorizedByID' => 'INT UNSIGNED NOT NULL',
+'DepartmentID' => 'INT UNSIGNED NOT NULL',
+'EndDateTime' => 'DATETIME NOT NULL',
+'EnteredByID' => 'INT UNSIGNED NOT NULL',
+'EventID' => 'INT UNSIGNED NOT NULL',
+'TimeModifier' => 'FLOAT(2,1) NOT NULL',
+    ],
+'VolunteerRewards' => [
+'PrizeID' => 'INT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT',
+'Name' => 'VARCHAR(50) NOT NULL',
+'Promo' => 'BOOLEAN',
+'RewardGroupID' => 'INT UNSIGNED',
+'TotalInventory' => 'INT NOT NULL',
+'Value' => 'DECIMAL(5,2) NOT NULL',
+    ]
+
+];
+
+$DB_foreignKeys = [
+'VolunteerHours' => [
+'DepartmentID' => 'Departments (DepartmentID) ON DELETE RESTRICT ON UPDATE CASCADE',
+'EventID' => 'Events (EventID) ON DELETE RESTRICT ON UPDATE CASCADE',
+    ],
+'VolunteerRewards' => [
+'RewardGroupID' => 'RewardGroup (RewardGroupID) ON DELETE RESTRICT ON UPDATE CASCADE',
+    ]
+
+];
+
+$MODULE_TABLES = array_merge($MODULE_TABLES, $DB_tables);
+$MODULE_FOREIGNKEYS = array_merge($MODULE_FOREIGNKEYS, $DB_foreignKeys);


### PR DESCRIPTION
This allows us to break down and shorten the master
data/database-schema.php file.

Note: that all pieces of the schema will be loaded even if a module is
disabled. This just allows for far less rebuilding of the database
even if modules are turned on or off.

This patch does not completely remove all the module pieces from the
database-schema.php but it makes a good first pass and establishes a
baseline for modules moving forward.