### PR TITLE
Make load less loud

### DIFF
--- a/backends/asset/file.inc
+++ b/backends/asset/file.inc
@@ -75,10 +75,15 @@ class Asset
             $base64 = base64_encode($data);
             return ("data:image/png;base64,".$base64);
         } elseif (array_key_exists('FILE_ASSET_PATH', $GLOBALS)) {
-            return (
-            $GLOBALS['FILE_ASSET_PATH'].'/'.$id.'.png?'.md5_file(
-                $GLOBALS['FILE_ASSET_PATH'].'/'.$id.'.png'
-            ));
+            $filename = $GLOBALS['FILE_ASSET_PATH'].'/'.$id.'.png';
+            if (is_file($filename)) {
+                return (
+                $GLOBALS['FILE_ASSET_PATH'].'/'.$id.'.png?'.md5_file(
+                    $GLOBALS['FILE_ASSET_PATH'].'/'.$id.'.png'
+                ));
+            } else {
+                return "";
+            }
         } else {
             return "";
         }


### PR DESCRIPTION
`Asset#load` was noisy about missing files. Maybe it should be, but it shouldn't spew 404s for every single request because org-icon isn't in place (unless we're going to supply a default org-icon, in which case, it being missing would be a real error)