### PR TITLE
Don't add undefined if inParameter is undefined!

### DIFF
--- a/sitesupport/common.js
+++ b/sitesupport/common.js
@@ -135,7 +135,7 @@ function apiRequest(method, target, inParameter) {
     var url = window.location.protocol + '//' + window.location.host + '/api/' +
               target;
     if (method == 'GET') {
-      if (inParameter !== null) {
+      if (inParameter) {
         if (url.indexOf('?') != -1) {
           url += '&' + inParameter;
         } else {


### PR DESCRIPTION
In Javascript, `null` and `undefined` are two different states. Checking for `null` was allowing `undefined` to get tacked on as a parameter to every GET call.

Checking just for existence at all (`if (inParameter)`) does what we want.