### PR TITLE
Block duplicated email

### DIFF
--- a/data/database-schema.php
+++ b/data/database-schema.php
@@ -113,6 +113,7 @@ class SCHEMA
             'PreferredFirstName' => 'VARCHAR(50)',
             'PreferredLastName' => 'VARCHAR(50)',
             'DisplayPhone' => 'BOOLEAN',
+            'dependentOnID' => 'INT UNSIGNED',
         ]
 
     ];
@@ -139,6 +140,9 @@ class SCHEMA
         ],
         'ConfigurationOption' => [
             'Field' => 'ConfigurationField (Field) ON DELETE RESTRICT ON UPDATE CASCADE',
+        ],
+        'Members' => [
+            'dependentOnID' => 'Members (AccountID) ON DELETE RESTRICT ON UPDATE CASCADE',
         ],
 
     ];

--- a/functions/users.inc
+++ b/functions/users.inc
@@ -21,6 +21,25 @@ function _quote($value)
 }
 
 
+function _duplicate_email($aid, $email)
+{
+    $sql = <<<SQL
+        SELECT *
+        FROM `Members`
+        WHERE `AccountID` != $aid AND
+              `Email` = '$email'
+        ORDER BY `AccountID` ASC
+SQL;
+    $result = \DB::run($sql);
+    $data = $result->fetchAll();
+    if (empty($data)) {
+        return null;
+    }
+    return $data[0]['AccountID'];
+
+}
+
+
 function _memberDBfromList($person)
 {
     $aid = $person['Account ID'];
@@ -28,7 +47,14 @@ function _memberDBfromList($person)
     $ln = _quote($person['Last Name']);
     $mn = _quote($person['Middle Name']);
     $su = _quote($person['Suffix']);
-    $em1 = _quote($person['Email 1']);
+    $existing = _duplicate_email($aid, $person['Email 1']);
+    if ($existing !== null) {
+        $em1 = 'NULL';
+        $dep = $existing;
+    } else {
+        $em1 = _quote($person['Email 1']);
+        $dep = 'NULL';
+    }
     $em2 = _quote($person['Email 2']);
     $em3 = _quote($person['Email 3']);
     $ph1 = _quote($person['Phone 1 Full Number (F)']);
@@ -67,17 +93,17 @@ function _memberDBfromList($person)
             AddressState, AddressZipCode, AddressZipCodeSuffix,
             AddressCountry, AddressProvince, PreferredFirstName,
             PreferredLastName, Login, Deceased, DoNotContact, EmailOptOut,
-            Birthdate, Gender, DisplayPhone)
+            Birthdate, Gender, DisplayPhone, dependentOnID)
         VALUES ($aid, $fn, $mn,$ln,
                 $su, $em1, $em2, $em3, $ph1, $ph2,
                 $al1, $al2, $ac,
                 $ast, $az, $azs,
                 $aco, $ap, $pfn,
                 $pln, $li, $dc, $dnc, $eoo,
-               $dob, $gn, $dph)
+               $dob, $gn, $dph, $dep)
         ON DUPLICATE KEY UPDATE
             FirstName=$fn, MiddleName=$mn, LastName=$ln, Suffix=$su,
-            Email=$em1, Email2=$em2, Email3=$em3, Phone=$ph1, Phone2=$ph2,
+            Email2=$em2, Email3=$em3, Phone=$ph1, Phone2=$ph2,
             AddressLine1=$al1, AddressLine2=$al2, AddressCity=$ac,
             AddressState=$ast, AddressZipCode=$az,
             AddressZipCodeSuffix=$azs, AddressCountry=$aco,

--- a/tools/clean_duplicate_accounts.php
+++ b/tools/clean_duplicate_accounts.php
@@ -1,0 +1,134 @@
+<?php
+/*.
+    require_module 'standard';
+.*/
+
+require_once(__DIR__."/../functions/functions.inc");
+
+$dependsField = 'dependentOnID';
+$do_update = false;
+
+
+function find_duplicates()
+{
+    $sql = <<<SQL
+        SELECT
+            *
+        FROM
+            `Members` AS base
+        WHERE
+            (
+            SELECT
+                COUNT(AccountID) AS COUNT
+            FROM
+                `Members`
+            WHERE
+                Email = base.Email
+        ) > 1
+        ORDER BY
+            `base`.`Email` ASC;
+SQL;
+    $sth = \DB::run($sql);
+    $data = $sth->fetchAll();
+    if (empty($data)) {
+        return null;
+    }
+
+    $result = [];
+    foreach ($data as $entry) {
+        $email = strtolower($entry['Email']);
+        if (array_key_exists($email, $result)) {
+            $result[$email][$entry['AccountID']] = $entry;
+        } else {
+            $result[$email] = [];
+            $result[$email][$entry['AccountID']] = $entry;
+        }
+    }
+
+    return $result;
+
+}
+
+
+function score_entry(/*.array.*/$entry)
+{
+    $score = 0;
+    if (!empty($entry['Login'])) {
+        $score += 1;
+    }
+    if (!empty($entry['AddressLine1'])) {
+        $score += 1;
+    }
+
+    return $score;
+
+}
+
+
+function find_prime_account(/*.array.*/$entries)
+{
+    if (count($entries) < 2) {
+        return array_keys($entries)[0];
+    }
+
+    $scores = [];
+    foreach ($entries as $key => $entry) {
+        $scores[$key] = score_entry($entry);
+    }
+    $top = array_keys($scores, max($scores));
+
+    return min($top);
+
+}
+
+
+function cleanup_duplicates(/*.array.*/$entries, /*.int.*/ $prime)
+{
+    global $dependsField, $do_update;
+
+    print("Base accountID ".$prime."(".$entries[$prime]['Email'].") dependent accounts: [");
+
+    foreach ($entries as $id => $entry) {
+        if ($id == $prime) {
+            continue;
+        }
+        print($id.' ');
+        if ($do_update) {
+            $sql = <<<SQL
+    UPDATE `Members`
+    SET
+        Email = NULL,
+        $dependsField = $prime
+    WHERE
+        AccountID = $id
+SQL;
+            \DB::run($sql);
+            $sql = <<<SQL
+    DELETE FROM `Authentication`
+    WHERE AccountID = $id
+SQL;
+            \DB::run($sql);
+        }
+    }
+    print("]\n");
+
+}
+
+
+if (array_key_exists('update', $_GET) &&
+    intval($_GET['update']) == 1) {
+    $do_update = true;
+}
+
+print("<pre><======== Begin duplicate cleanup ");
+if (!$do_update) {
+    print("(DRYRUN)");
+}
+print(" ========>\n");
+$dups = find_duplicates();
+print("Cleaning ".count($dups)." entries\n");
+foreach ($dups as $dup) {
+    $acc = find_prime_account($dup);
+    cleanup_duplicates($dup, $acc);
+}
+print("<======== End duplicate cleanup ========></pre>\n");


### PR DESCRIPTION
This transition is going to be a bit timing sensitive.

You will want to run the clean_duplicate_accounts tool via the web
when there is no neon update running.  Have ?update=1 to do the work
otherwise it will be a dry-run.

Then when the next neon update occures it should properly
not re-duplicate accounts and new neon accounts should not end up as
duplicates.

However if a neon update occures after this patch is applies and
before you run clean_duplicate_accounts, then the neon update will
behave a bit unpredictable around accounts with duplicate email and
may not assige the correct primary account.