### PR TITLE
Introduce the idea of a NotFoundException handler

### DIFF
--- a/api/src/Controller/BaseController.php
+++ b/api/src/Controller/BaseController.php
@@ -6,6 +6,7 @@
 namespace App\Controller;
 
 use ArrayObject;
+use Exception;
 
 use Slim\Container;
 use Slim\Http\Response;
@@ -13,6 +14,11 @@ use Slim\Http\Request;
 
 require_once __DIR__.'/../../../backends/RBAC.inc';
 require_once __DIR__.'/../../../functions/divisional.inc';
+
+class NotFoundException extends Exception
+{
+
+}
 
 abstract class BaseController
 {
@@ -75,7 +81,15 @@ abstract class BaseController
 
     public function __invoke(Request $request, Response $response, $args)
     {
-        $result = $this->buildResource($request, $response, $args);
+        try {
+            $result = $this->buildResource($request, $response, $args);
+        } catch (NotFoundException $e) {
+            $result = [
+            BaseController::RESULT_TYPE,
+            $this->errorResponse($request, $response, $e->getMessage(), 'Not Found', 404)
+            ];
+        }
+
         if ($result === null || $result[0] === null) {
             return null;
         }

--- a/api/src/Controller/Stores/BaseProduct.php
+++ b/api/src/Controller/Stores/BaseProduct.php
@@ -7,7 +7,9 @@ use Atlas\Query\Select;
 use Slim\Container;
 use Slim\Http\Request;
 use Slim\Http\Response;
+
 use App\Controller\BaseController;
+use App\Controller\NotFoundException;
 
 abstract class BaseProduct extends BaseController
 {
@@ -43,12 +45,7 @@ abstract class BaseProduct extends BaseController
         $product = $select->fetchOne();
 
         if (empty($product)) {
-            $error = [
-            BaseController::RESULT_TYPE,
-            $this->errorResponse($request, $response, "Could not find Product with ID ${params['id']}", 'Not found', 404)
-            ];
-            
-            return null;
+            throw new NotFoundException("Could not find Product with ID ${params['id']}");
         }
 
         return $product;

--- a/api/src/Controller/Stores/BaseStore.php
+++ b/api/src/Controller/Stores/BaseStore.php
@@ -7,7 +7,9 @@ use Atlas\Query\Select;
 use Slim\Container;
 use Slim\Http\Request;
 use Slim\Http\Response;
+
 use App\Controller\BaseController;
+use App\Controller\NotFoundException;
 
 abstract class BaseStore extends BaseController
 {
@@ -41,11 +43,7 @@ abstract class BaseStore extends BaseController
         $store = $select->columns('StoreID as id', 'Name', 'StoreSlug', 'Description')->from('Stores')->whereEquals(['StoreID' => $params['id']])->fetchOne();
 
         if (empty($store)) {
-            $error = [
-            BaseController::RESULT_TYPE,
-            $this->errorResponse($request, $response, "Could not find Store ID ${params['id']}", 'Not found', 404)
-            ];
-            return null;
+            throw new NotFoundException("Could not find Store ID ${params['id']}");
         }
 
         return $store;

--- a/api/src/Controller/Stores/GetProduct.php
+++ b/api/src/Controller/Stores/GetProduct.php
@@ -21,11 +21,7 @@ class GetProduct extends BaseProduct
         }
 
         $product = $this->getProduct($params, $request, $response, $error);
-
-        if (empty($product)) {
-            return $error;
-        }
-
+        
         return [
         BaseController::RESOURCE_TYPE,
         $product

--- a/api/src/Controller/Stores/GetStore.php
+++ b/api/src/Controller/Stores/GetStore.php
@@ -13,10 +13,6 @@ class GetStore extends BaseStore
     {
         $store = $this->getStore($params, $request, $response, $error);
 
-        if (empty($store)) {
-            return $error;
-        }
-
         return [
         \App\Controller\BaseController::RESOURCE_TYPE,
         $store

--- a/api/src/Controller/Stores/PostProduct.php
+++ b/api/src/Controller/Stores/PostProduct.php
@@ -64,10 +64,6 @@ class PostProduct extends BaseProduct
         $id = $insert->getLastInsertId();
 
         $product = $this->getProduct(array('id' => $id), $request, $response, $error);
-
-        if (empty($product)) {
-            return $error;
-        }
         
         $output = array(
             'type' => 'product',

--- a/api/src/Controller/Stores/PostStore.php
+++ b/api/src/Controller/Stores/PostStore.php
@@ -39,10 +39,6 @@ class PostStore extends BaseStore
 
         $store = $this->getStore(array('id' => $id), $request, $response, $error);
 
-        if (empty($store)) {
-            return $error;
-        }
-
         $output = array(
             'type' => 'store',
             'data' => $store


### PR DESCRIPTION
Allow 404 handling to be centralized and DRY'd up by having get methods throw a `NotFoundException` instead of having to handle it locally.