### PR TITLE
Deglobalize DB schema init

### DIFF
--- a/functions/database.inc
+++ b/functions/database.inc
@@ -7,19 +7,21 @@
 
 // Currently, this database class is set for the MySQL PDO filter/backend. Future version will expand it to be agnostic
 
+require_once(__DIR__.'/functions.inc');
 require_once(__DIR__.'/locations.inc');
 require_once($BACKEND.'/'.$_ENV['DB_BACKEND']); // MyPDO Definition used
 require_once($BASEDIR.'/data/database-schema.php');
 
-
-$MODULE_TABLES = array();
-$MODULE_FOREIGNKEYS = array();
-$MODULE_PRIMARYKEYS = array();
-$MODULE_INDEX = array();
-
-
 class DB
 {
+
+    private static $MODULE_TABLES = array();
+
+    private static $MODULE_FOREIGNKEYS = array();
+
+    private static $MODULE_PRIMARYKEYS = array();
+
+    private static $MODULE_INDEX = array();
 
     /**
      * @var array
@@ -30,6 +32,38 @@ class DB
      * @var boolean
      */
     private $loaded = false;
+
+
+    public static function addTables(array $tables): array
+    {
+        self::$MODULE_TABLES = array_merge(self::$MODULE_TABLES, $tables);
+        return self::$MODULE_TABLES;
+
+    }
+
+
+    public static function addForeignKeys(array $fks): array
+    {
+        self::$MODULE_FOREIGNKEYS = array_merge(self::$MODULE_FOREIGNKEYS, $fks);
+        return self::$MODULE_FOREIGNKEYS;
+
+    }
+
+
+    public static function addPrimaryKeys(array $pks): array
+    {
+        self::$MODULE_PRIMARYKEYS = array_merge(self::$MODULE_PRIMARYKEYS, $pks);
+        return self::$MODULE_PRIMARYKEYS;
+
+    }
+
+
+    public static function addIndexes(array $indexes): array
+    {
+        self::$MODULE_INDEX = array_merge(self::$MODULE_INDEX, $indexes);
+        return self::$MODULE_INDEX;
+
+    }
 
 
     private static function verifyDB()
@@ -171,7 +205,7 @@ SQL;
 
         // Capture a list of all Constraints (Foreign Keys)
         $build = "SELECT TABLE_NAME, COLUMN_NAME FROM information_schema.KEY_COLUMN_USAGE";
-        $build .= " WHERE TABLE_SCHEMA = '".$GLOBALS['DBNAME']."' AND CONSTRAINT_NAME <> 'PRIMARY';";
+        $build .= " WHERE TABLE_SCHEMA = '".$_ENV['DBNAME']."' AND CONSTRAINT_NAME <> 'PRIMARY';";
         $result = MyPDO::instance()->query($build);
         $arr = [];
         foreach ($result as $value) {
@@ -200,7 +234,7 @@ SQL;
 
             $desired_indexes = array_keys($indexes);
             $indexes_to_add = array_diff($desired_indexes, $current_indexes);
-            
+
             foreach ($indexes_to_add as $index_to_add) {
                 $columns = $indexes[$index_to_add];
                 $sql = "CREATE INDEX ".$index_to_add." ON ".$table." (`".implode("`, `", $columns)."`);";
@@ -216,7 +250,7 @@ SQL;
 
     public function loadModules()
     {
-        global $MODULE_TABLES, $MODULESDIR, $MODULE_FOREIGNKEYS, $MODULE_PRIMARYKEYS, $MODULE_INDEX;
+        global $MODULESDIR;
 
         if ($this->loaded) {
             return;
@@ -236,10 +270,10 @@ SQL;
             error_log("ERROR!!! Database Schema import failed: ".$e);
         }
 
-        $this->schema['tables'] = array_merge($this->schema['tables'], $MODULE_TABLES);
-        $this->schema['foreignKeys'] = array_merge($this->schema['foreignKeys'], $MODULE_FOREIGNKEYS);
-        $this->schema['primaryKeys'] = array_merge($this->schema['primaryKeys'], $MODULE_PRIMARYKEYS);
-        $this->schema['index'] = array_merge($this->schema['index'], $MODULE_INDEX);
+        $this->schema['tables'] = array_merge($this->schema['tables'], self::$MODULE_TABLES);
+        $this->schema['foreignKeys'] = array_merge($this->schema['foreignKeys'], self::$MODULE_FOREIGNKEYS);
+        $this->schema['primaryKeys'] = array_merge($this->schema['primaryKeys'], self::$MODULE_PRIMARYKEYS);
+        $this->schema['index'] = array_merge($this->schema['index'], self::$MODULE_INDEX);
         $this->loaded = true;
 
     }
@@ -283,7 +317,7 @@ SQL;
         if (substr(ltrim($sql), 0, 6) !== "SELECT") {
             // Prepare a log entry for this query
             $logMessage = MyPDO::instance()->prepare('INSERT INTO ActivityLog (AccountID, Function, Query) VALUES (:account, :function, :query);');
-        
+
             if (empty($_SESSION['accountId'])) {
                 $account = 0;
             } else {

--- a/modules/announcements/database-schema.inc
+++ b/modules/announcements/database-schema.inc
@@ -26,5 +26,5 @@ $DB_foreignKeys = [
 
 ];
 
-$MODULE_TABLES = array_merge($MODULE_TABLES, $DB_tables);
-$MODULE_FOREIGNKEYS = array_merge($MODULE_FOREIGNKEYS, $DB_foreignKeys);
+\DB::addTables($DB_tables);
+\DB::addForeignKeys($DB_foreignKeys);

--- a/modules/concom/database-schema.inc
+++ b/modules/concom/database-schema.inc
@@ -44,6 +44,6 @@ $concom_DB_index = [
     ]
 ];
 
-$MODULE_TABLES = array_merge($MODULE_TABLES, $concom_DB_tables);
-$MODULE_FOREIGNKEYS = array_merge($MODULE_FOREIGNKEYS, $concom_DB_foreignKeys);
-$MODULE_INDEX = array_merge($MODULE_INDEX, $concom_DB_index);
+\DB::addTables($concom_DB_tables);
+\DB::addForeignKeys($concom_DB_foreignKeys);
+\DB::addIndexes($concom_DB_index);

--- a/modules/deadlines/database-schema.inc
+++ b/modules/deadlines/database-schema.inc
@@ -23,5 +23,5 @@ $DB_foreignKeys = [
 
 ];
 
-$MODULE_TABLES = array_merge($MODULE_TABLES, $DB_tables);
-$MODULE_FOREIGNKEYS = array_merge($MODULE_FOREIGNKEYS, $DB_foreignKeys);
+\DB::addTables($DB_tables);
+\DB::addForeignKeys($DB_foreignKeys);

--- a/modules/emailer/database-schema.inc
+++ b/modules/emailer/database-schema.inc
@@ -28,5 +28,5 @@ $DB_primaryKeys = [
 
 ];
 
-$MODULE_TABLES = array_merge($MODULE_TABLES, $DB_tables);
-$MODULE_PRIMARYKEYS = array_merge($MODULE_PRIMARYKEYS, $DB_primaryKeys);
+\DB::addTables($DB_tables);
+\DB::addPrimaryKeys($DB_primaryKeys);

--- a/modules/emailer/functions/emailer.inc
+++ b/modules/emailer/functions/emailer.inc
@@ -436,7 +436,7 @@ SQL;
         $result = \DB::run($sql);
         $value = $result->fetch();
         if ($value === false) {
-            $sql = "SELECT `COLUMN_NAME` FROM `INFORMATION_SCHEMA`.`COLUMNS` WHERE `TABLE_SCHEMA`='".$GLOBALS['DBNAME']."' AND `TABLE_NAME`='EmailListAccess';";
+            $sql = "SELECT `COLUMN_NAME` FROM `INFORMATION_SCHEMA`.`COLUMNS` WHERE `TABLE_SCHEMA`='".$_ENV['DBNAME']."' AND `TABLE_NAME`='EmailListAccess';";
             $result = \DB::run($sql);
             $data = ['Department' => null,
             'Position' => null];

--- a/modules/event/database-schema.inc
+++ b/modules/event/database-schema.inc
@@ -84,5 +84,5 @@ $event_DB_foreignKeys = [
 
 ];
 
-$MODULE_TABLES = array_merge($MODULE_TABLES, $event_DB_tables);
-$MODULE_FOREIGNKEYS = array_merge($MODULE_FOREIGNKEYS, $event_DB_foreignKeys);
+\DB::addTables($event_DB_tables);
+\DB::addForeignKeys($event_DB_foreignKeys);

--- a/modules/registration/database-schema.inc
+++ b/modules/registration/database-schema.inc
@@ -15,4 +15,4 @@ $DB_tables = [
 
 ];
 
-$MODULE_TABLES = array_merge($MODULE_TABLES, $DB_tables);
+\DB::addTables($DB_tables);

--- a/modules/store/database-schema.inc
+++ b/modules/store/database-schema.inc
@@ -61,6 +61,6 @@ $DB_foreignKeys = [
     ]
 ];
 
-$MODULE_TABLES = array_merge($MODULE_TABLES, $DB_tables);
-$MODULE_FOREIGNKEYS = array_merge($MODULE_FOREIGNKEYS, $DB_foreignKeys);
-$MODULE_INDEX = array_merge($MODULE_INDEX, $DB_index);
+\DB::addTables($DB_tables);
+\DB::addForeignKeys($DB_foreignKeys);
+\DB::addIndexes($DB_index);

--- a/modules/volunteers/database-schema.inc
+++ b/modules/volunteers/database-schema.inc
@@ -54,5 +54,5 @@ $vol_DB_foreignKeys = [
 
 ];
 
-$MODULE_TABLES = array_merge($MODULE_TABLES, $vol_DB_tables);
-$MODULE_FOREIGNKEYS = array_merge($MODULE_FOREIGNKEYS, $vol_DB_foreignKeys);
+\DB::addTables($vol_DB_tables);
+\DB::addForeignKeys($vol_DB_foreignKeys);


### PR DESCRIPTION
Also remove the lingering use of $GLOBALS['DBNAME'] in favour of $_ENV['DBNAME'] as everywhere else.