### PR TITLE
Run tests in a separate database with a clean start every time

### DIFF
--- a/Docker.md
+++ b/Docker.md
@@ -8,7 +8,18 @@ The goal here is to try to get a development environment on a machine that may n
 
 1. You are going to need [composer](https://getcomposer.org/download/) setup and make sure to do `php composer.phar install` or the command you need to do to get the vendor directory properly populated.
 
-1. You can now start docker running the command:  `./docker_instance.sh up`. Give it a few minutes to initialize and it will have the instance at "localhost:8080". If you are knowledgable about docker you can modify the `docker-compose.yml` file to change the port.
+1. Create a file called `.env`. Define the 6 variables listed (you can use these names; you can use other names; use something!) Both the PHP code AND the Docker management scripts depend upon them.
+
+    ```shell
+    export DBUSER=ciabuser
+    export DBPASS=ciabpass
+    export DBROOTPW=deathllama
+    export DBNAME=ciab
+    export TEST_DBNAME=ciab-test
+    export DB_BACKEND=mysqlpdo.inc
+    ```
+
+1. You can now start docker running the command:  `./bin/docker_instance.sh up`. Give it a few minutes to initialize and it will have the instance at "localhost:8080". If you are knowledgable about docker you can modify the `docker-compose.yml` file to change the port.
 
 1. Once you visit <http://localhost:8080> and get a login screen you need to do the first time configuration. Visit <http://localhost:8080/configure_system.php> and that will get things setup. _DO NOT CHANGE_ any of the prepopulated database values. *ALSO PLEASE NOTE:* The `configure_system.php` redirect will not happen automatically like in normal bare-metal first time runs.
 
@@ -18,8 +29,8 @@ The goal here is to try to get a development environment on a machine that may n
 
 1. If you want to fill the database with dummy volunteer data then you can use the php script by loading <http://localhost:8080/test/populate_volunteer.php>
 
-1. When you are done and want to bring docker down you can use the command `./docker_instance.sh down`
+1. When you are done and want to bring docker down you can use the command `./bin/docker_instance.sh down`
 
-1. If you are a docker poweruser feel freee to add other `docker-compose` parameters to the `docker_instance.sh` commands and they should be passed through. 
+1. If you are a docker poweruser feel free to add other `docker-compose` parameters to the `docker_instance.sh` commands and they should be passed through.
 
 1. When using docker, mail will be delivered to an ephemeral service called `mailcatcher`. You can see what mailcatcher has caught at <http://localhost:1080>.

--- a/FirstSetup.md
+++ b/FirstSetup.md
@@ -1,5 +1,7 @@
 # How to get setup for your very first install and run.
 
+**IMPORTANT** If you are using Docker, read [Docker.md](Docker.md) instead!
+
 1. Make sure you have this on your box with a web server and you have a database server setup. Ideally this project should be at the document root for the web server. You of course need PHP enabled on your web server.
     1. Note: the apache server needs the headers and php7 modules
     1. Note: php needs the libcurl integration (php7-curl)
@@ -24,4 +26,4 @@ The goal is to import NEON data, that we cannot random access read, in a regular
 To your crontab add this line
 `*/5 * * * * php <full path to package>/tools/sync_neon_event_to_db.php 1>/dev/null`
 
-That will then sync the Neon data every 5 minutes. Note that sync_neon_event_to_db.php will not run if it is already running. So you will not have to worry about overwhelming the system resources. But it does mean that worst case is that there is a 5 minute delay between the updates, if an update takes several minutes that will determine what your out-of-date factor will be. 
+That will then sync the Neon data every 5 minutes. Note that sync_neon_event_to_db.php will not run if it is already running. So you will not have to worry about overwhelming the system resources. But it does mean that worst case is that there is a 5 minute delay between the updates, if an update takes several minutes that will determine what your out-of-date factor will be.

--- a/api/index.php
+++ b/api/index.php
@@ -13,4 +13,6 @@ set_error_handler(function ($severity, $message, $file, $line) {
     }
 });
 
+_config_from_Database();
+
 $app->run();

--- a/api/index.php
+++ b/api/index.php
@@ -1,5 +1,9 @@
 <?php
 
+if (!array_key_exists('DISABLEDMODULES', $GLOBALS)) {
+    $GLOBALS['DISABLEDMODULES'] = array();
+}
+
 require __DIR__.'/src/App/App.php';
 
 error_reporting(E_ALL);

--- a/api/src/App/App.php
+++ b/api/src/App/App.php
@@ -27,6 +27,8 @@ setupAPIOAuth2($app, $server);
 $authMiddleware = new Middleware\Authorization($server, $container);
 setupAPIRoutes($app, $authMiddleware);
 
+global $DISABLEDMODULES;
+
 $modules = scandir(__DIR__.'/../Modules');
 foreach ($modules as $key => $value) {
     if (!in_array($value, array(',', '..'))) {

--- a/api/src/Modules/concom/ModuleConcom.php
+++ b/api/src/Modules/concom/ModuleConcom.php
@@ -9,6 +9,8 @@ use App\Modules\BaseModule;
 use Slim\Http\Request;
 use Slim\Http\Response;
 
+require_once __DIR__.'/../../../../modules/concom/functions/POSITION.inc';
+
 class ModuleConcom extends BaseModule
 {
 

--- a/api/src/Tests/Base/CiabTestCase.php
+++ b/api/src/Tests/Base/CiabTestCase.php
@@ -62,6 +62,9 @@ abstract class CiabTestCase extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
+
+        _config_from_Database();
+
         $settings = require __DIR__.'/../../App/Settings.php';
         $this->app = new \Slim\App($settings);
         $this->middleware = new BlankMiddleWare();

--- a/bin/docker_instance.sh
+++ b/bin/docker_instance.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
 
+source .env
+
 if [ "$1" == "up" ]; then
     shift
-    DBUSER="ciabuser" DBNAME="ciab" DBPASS="ciabpass" DB_BACKEND="mysqlpdo.inc" docker-compose -f docker-compose.yml -f docker-compose.phpmyadmin.yml up $@
+    docker-compose -f docker-compose.yml -f docker-compose.phpmyadmin.yml up $@
 elif [ "$1" == "down" ]; then
     shift
     docker-compose -f docker-compose.yml -f docker-compose.phpmyadmin.yml down $@;

--- a/bin/resetdb.sh
+++ b/bin/resetdb.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+source .env
+
+docker-compose down --remove-orphans
+docker volume prune -f
+./bin/docker_instance.sh up -d
+
+echo "Waiting a few seconds for the various containers to re-initialize!"
+sleep 10
+
+echo "Creating test db"
+docker-compose exec -T mysql mysql -uroot -hlocalhost -p${DBROOTPW} --protocol=socket <<-SQL
+CREATE DATABASE IF NOT EXISTS \`${TEST_DBNAME}\` ;
+SQL
+
+docker-compose exec -T mysql mysql -uroot -hlocalhost -p${DBROOTPW} --protocol=socket <<-SQL
+GRANT ALL ON \`${TEST_DBNAME}\`.* to '${DBUSER}'@'%' ;
+SQL

--- a/bin/run_coverage.sh
+++ b/bin/run_coverage.sh
@@ -1,3 +1,7 @@
 #!/bin/bash
 source .env
+export DBNAME=${TEST_DBNAME}
+
+docker-compose run --rm php php tools/create_schema.php
+docker-compose run --rm php php tools/test_prereqs.php
 docker-compose run --rm php ./vendor/bin/phpunit --configuration phpunit.xml --coverage-clover build/logs/clover.xml --coverage-html build/coverage api

--- a/bin/run_test.sh
+++ b/bin/run_test.sh
@@ -1,3 +1,7 @@
 #!/bin/bash
 source .env
+export DBNAME=${TEST_DBNAME}
+
+docker-compose run --rm php php tools/create_schema.php
+docker-compose run --rm php php tools/test_prereqs.php
 docker-compose run --rm php ./vendor/bin/phpunit --configuration phpunit.xml api

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
         DBNAME: ${DBNAME}
         DBPASS: ${DBPASS}
         DBUSER: ${DBUSER}
+        TEST_DBNAME: ${TEST_DBNAME}
         DB_BACKEND: ${DB_BACKEND}
         API_SERVER: "http://apache"
         DOCKER: 1
@@ -41,7 +42,7 @@ services:
     networks:
       - backend
     environment:
-      MYSQL_RANDOM_ROOT_PASSWORD: 1
+      MYSQL_ROOT_PASSWORD: ${DBROOTPW}
       MYSQL_DATABASE: ${DBNAME}
       MYSQL_PASSWORD: ${DBPASS}
       MYSQL_USER: ${DBUSER}

--- a/functions/database.inc
+++ b/functions/database.inc
@@ -7,7 +7,6 @@
 
 // Currently, this database class is set for the MySQL PDO filter/backend. Future version will expand it to be agnostic
 
-require_once(__DIR__.'/functions.inc');
 require_once(__DIR__.'/locations.inc');
 require_once($BACKEND.'/'.$_ENV['DB_BACKEND']); // MyPDO Definition used
 require_once($BASEDIR.'/data/database-schema.php');

--- a/functions/functions.inc
+++ b/functions/functions.inc
@@ -8,6 +8,7 @@
 require_once(__DIR__."/../backends/email.inc");
 require __DIR__."/../vendor/autoload.php";
 require_once(__DIR__."/locations.inc");
+require_once(__DIR__."/database.inc");
 
 // Main setup function
 $MODULENAME  = "Member Portal";
@@ -161,59 +162,64 @@ SQL;
 }
 
 
-// Load Site Specific info
-try {
-    if (isset($dotenv)) {
-        $dotenv->required(['DBHOST', 'DBUSER', 'DBNAME', 'DBPASS', 'DB_BACKEND']);
-    }
+function initializeApplication()
+{
+    // Load Site Specific info
+    try {
+        if (isset($dotenv)) {
+            $dotenv->required(['DBHOST', 'DBUSER', 'DBNAME', 'DBPASS', 'DB_BACKEND']);
+        }
 
-    // Include the Master Database
-    require_once(__DIR__."/database.inc");
-    $db = new DB;
-    _config_from_Database();
+        // Include the Master Database
+        $db = new DB;
+        _config_from_Database();
 
-    // Include NeonCRM for DB calls via API
-    if (array_key_exists('NEONID', $GLOBALS) &&
-        array_key_exists('NEONKEY', $GLOBALS) &&
-        !empty($GLOBALS['NEONID']) &&
-        !empty($GLOBALS['NEONKEY'])) {
-        require_once(__DIR__."/neon.inc");
-    }
+        // Include NeonCRM for DB calls via API
+        if (array_key_exists('NEONID', $GLOBALS) &&
+            array_key_exists('NEONKEY', $GLOBALS) &&
+            !empty($GLOBALS['NEONID']) &&
+            !empty($GLOBALS['NEONKEY'])) {
+            require_once(__DIR__."/neon.inc");
+        }
 
-    // Load the base of all active modules
-    $modules = scandir($MODULESDIR);
-    foreach ($modules as $key => $value) {
-        if (!in_array($value, array(".", ".."))) {
-            if (array_key_exists('DISABLEDMODULES', $GLOBALS) &&
-                in_array($value, $GLOBALS['DISABLEDMODULES'])) {
-                continue;
-            }
-            if (is_dir($MODULESDIR.DIRECTORY_SEPARATOR.$value)) {
-                if (is_file($MODULESDIR.DIRECTORY_SEPARATOR.$value.DIRECTORY_SEPARATOR.'init.inc')) {
-                    require_once($MODULESDIR.DIRECTORY_SEPARATOR.$value.DIRECTORY_SEPARATOR.'init.inc');
+        global $MODULESDIR; // TODO: Deglobalize this
+
+        // Load the base of all active modules
+        $modules = scandir($MODULESDIR);
+        foreach ($modules as $key => $value) {
+            if (!in_array($value, array(".", ".."))) {
+                if (array_key_exists('DISABLEDMODULES', $GLOBALS) &&
+                    in_array($value, $GLOBALS['DISABLEDMODULES'])) {
+                    continue;
+                }
+                if (is_dir($MODULESDIR.DIRECTORY_SEPARATOR.$value)) {
+                    if (is_file($MODULESDIR.DIRECTORY_SEPARATOR.$value.DIRECTORY_SEPARATOR.'init.inc')) {
+                        require_once($MODULESDIR.DIRECTORY_SEPARATOR.$value.DIRECTORY_SEPARATOR.'init.inc');
+                    }
                 }
             }
         }
+    } catch (RuntimeException $e) {
+        // Give a default config file
+        echo '
+        <html>
+        <head>CON-In-A-Box Site Config ('.$MODULENAME.' module)</head>
+        <body>
+        <pre>
+            SITE CONFIGURATION ERROR -- Database Environment missing or incorrect.';
+        print "\n";
+        if (array_key_exists('DBPASS', $_ENV)) {
+            $_ENV['DBPASS'] = "&lt;&lt;hidden&gt;&gt;";
+        }
+        print_r($_ENV, false);
+        print_r($e, false);
+        echo '
+        </pre>
+        </body>
+    </html>';
+        die();
     }
-} catch (RuntimeException $e) {
-    // Give a default config file
-    echo '
-    <html>
-      <head>CON-In-A-Box Site Config ('.$MODULENAME.' module)</head>
-    <body>
-      <pre>
-        SITE CONFIGURATION ERROR -- Database Environment missing or incorrect.';
-    print "\n";
-    if (array_key_exists('DBPASS', $_ENV)) {
-        $_ENV['DBPASS'] = "&lt;&lt;hidden&gt;&gt;";
-    }
-    print_r($_ENV, false);
-    print_r($e, false);
-    echo '
-      </pre>
-    </body>
-  </html>';
-    die();
+
 }
 
 

--- a/index.php
+++ b/index.php
@@ -8,7 +8,14 @@
 // Start the session so we are ready to go no matter what we do!
 session_start();
 
+$DISABLEDMODULES = array(); // TODO: Deglobalize
+
 require_once __DIR__.'/functions/locations.inc';
+
+// Load in basic functions
+require_once __DIR__.'/functions/functions.inc';
+require_once __DIR__.'/console/console.inc';
+
 
 require __DIR__."/vendor/autoload.php";
 if (is_file(__DIR__.'/.env')) {
@@ -48,9 +55,7 @@ try {
     }
 }
 
-// Load in basic functions
-require_once __DIR__.'/functions/functions.inc';
-require_once __DIR__.'/console/console.inc';
+initializeApplication();
 
 // Divert to public page if we are not under function control
 if (empty($_REQUEST['Function'])) {

--- a/modules/concom/functions/LIST.inc
+++ b/modules/concom/functions/LIST.inc
@@ -6,6 +6,8 @@
 
 namespace concom;
 
+global $FUNCTIONDIR;
+
 require_once($FUNCTIONDIR.'/users.inc');
 require_once($FUNCTIONDIR.'/database.inc');
 

--- a/pages/base/header_start.inc
+++ b/pages/base/header_start.inc
@@ -16,7 +16,8 @@ if (!function_exists('get_console') || get_console() === null) {
     $modules = scandir($MODULESDIR);
     foreach ($modules as $key => $value) {
         if (!in_array($value, array(".", ".."))) {
-            if (in_array($value, $DISABLEDMODULES)) {
+            if (array_key_exists('DISABLEDMODULES', $GLOBALS) &&
+                in_array($value, $DISABLEDMODULES)) {
                 continue;
             }
             if (is_dir($MODULESDIR.DIRECTORY_SEPARATOR.$value) &&

--- a/test/populate_event.php
+++ b/test/populate_event.php
@@ -165,8 +165,8 @@ function new_cycle($start, $end)
 {
     print "$start - $end\n";
     $sql = <<<SQL
-            INSERT INTO `AnnualCycles` 
-                        (`AnnualCycleID`, `DateFrom`, `DateTo`) 
+            INSERT INTO `AnnualCycles`
+                        (`AnnualCycleID`, `DateFrom`, `DateTo`)
                         VALUES (NULL, "$start", "$end")
 SQL;
     \DB::run($sql);
@@ -382,7 +382,7 @@ function populate_registrations($event)
 
 }
 
-
+_config_from_Database();
 print "<pre>";
 if (array_key_exists('NEONID', $GLOBALS) &&
     array_key_exists('NEONKEY', $GLOBALS) &&

--- a/test/populate_event.php
+++ b/test/populate_event.php
@@ -382,6 +382,7 @@ function populate_registrations($event)
 
 }
 
+
 _config_from_Database();
 print "<pre>";
 if (array_key_exists('NEONID', $GLOBALS) &&

--- a/tools/create_schema.php
+++ b/tools/create_schema.php
@@ -1,0 +1,5 @@
+<?php
+
+require_once(__DIR__.'/../functions/database.inc');
+
+$db = new DB();

--- a/tools/test_prereqs.php
+++ b/tools/test_prereqs.php
@@ -1,0 +1,67 @@
+<?php declare(strict_types=1);
+
+require_once(__DIR__.'/../vendor/autoload.php');
+require_once(__DIR__.'/../backends/mysqlpdo.inc');
+
+use Atlas\Query\Delete;
+use Atlas\Query\Insert;
+use Atlas\Query\Select;
+use Atlas\Query\Update;
+
+// create_schema.php auto-seeds some things and not others.
+// Build what we need.
+
+$db = MyPDO::instance();
+
+$delete = Delete::new($db);
+$delete->from('ConComList')->perform();
+$delete->from('Events')->perform();
+$delete->from('AnnualCycles')->perform();
+$delete->from('Members')->perform();
+
+$select = Select::new($db);
+$select->columns('Value')->from('Configuration')->whereEquals(['Field' => 'ADMINACCOUNTS']);
+$val = $select->fetchOne();
+
+$val['Value'] = '1000,'.$val['Value'];
+
+$update = Update::new($db);
+$update->table('Configuration')->columns($val)->whereEquals(['Field' => 'ADMINACCOUNTS'])->perform();
+
+$insert = Insert::new($db);
+$insert->into('AnnualCycles')->columns([
+    'DateFrom' => date('Y-m-d', strtotime('1 October 2020')),
+    'DateTo' => date('Y-m-d', strtotime('30 September 2021'))
+])->perform();
+$cycleId = $insert->getLastInsertId();
+
+$insert = Insert::new($db);
+$insert->into('Events')->columns([
+    'AnnualCycleID' => $cycleId,
+    'DateFrom' => date('Y-m-d', strtotime('3 July 2021')),
+    'DateTo' => date('Y-m-d', strtotime('8 July 2021')),
+    'EventName' => 'AsgardCon'
+])->perform();
+$eventId = $insert->getLastInsertId();
+
+$insert = Insert::new($db);
+$insert->into('Members')->columns([
+    'AccountID' => 1000,
+    'FirstName' => 'Odin',
+    'LastName' => 'Allfather',
+    'Email' => 'allfather@oneeye.com',
+    'Gender' => 'Allfather'
+])->perform();
+
+$select = Select::new($db);
+$select->columns('PositionID')->from('ConComPositions')->whereEquals(['Name' => 'Head']);
+$val = $select->fetchOne();
+$posId = $val['PositionID'];
+
+$insert = Insert::new($db);
+$insert->into('ConComList')->columns([
+    'AccountID' => 1000,
+    'DepartmentID' => 1,
+    'EventID' => $eventId,
+    'PositionID' => $posId
+])->perform();


### PR DESCRIPTION
Right now, you still have to also run `./bin/resetdb.sh` to truly run with a clean database. This is not ideal, of course, since you may be playing with data in the dev database and not want that wiped out.

So, still to come, a parameterized ./bin/resetdb.sh that just resets either dev or test. But I wanted to get this up for you to start looking at.