### PR TITLE
Fix environments where we rely on .env 

### DIFF
--- a/api/src/App/App.php
+++ b/api/src/App/App.php
@@ -45,16 +45,17 @@
 use Chadicus\Slim\OAuth2\Middleware;
 
 require __DIR__.'/../../../vendor/autoload.php';
-require __DIR__.'/../../../functions/functions.inc';
-require_once __DIR__.'/../../../backends/oauth2.inc';
-require __DIR__.'/Dependencies.php';
-require __DIR__.'/Routes.php';
-require __DIR__.'/OAuth2.php';
 
 if (is_file(__DIR__.'/../../../.env')) {
     $dotenv = Dotenv\Dotenv::create(__DIR__.'/../../..');
     $dotenv->load();
 }
+
+require __DIR__.'/../../../functions/functions.inc';
+require_once __DIR__.'/../../../backends/oauth2.inc';
+require __DIR__.'/Dependencies.php';
+require __DIR__.'/Routes.php';
+require __DIR__.'/OAuth2.php';
 
 $settings = require __DIR__.'/Settings.php';
 $app = new \Slim\App($settings);

--- a/api/src/Tests/Base/CiabTestCase.php
+++ b/api/src/Tests/Base/CiabTestCase.php
@@ -10,6 +10,11 @@ use Slim\Http\Environment;
 use App\Tests\Base\BlankMiddleWare;
 use Chadicus\Slim\OAuth2\Middleware;
 
+if (is_file(__DIR__.'/../../../../.env')) {
+    $dotenv = \Dotenv\Dotenv::create(__DIR__.'/../../../..');
+    $dotenv->load();
+}
+
 require __DIR__.'/../../App/Routes.php';
 require __DIR__.'/../../App/Dependencies.php';
 require __DIR__.'/../../App/OAuth2.php';
@@ -71,11 +76,6 @@ abstract class CiabTestCase extends TestCase
         parent::setUpBeforeClass();
         $already_loaded = array_key_exists('init', $GLOBALS);
         $GLOBALS['init'] = true;
-
-        if (is_file(__DIR__.'/../../../../.env')) {
-            $dotenv = \Dotenv\Dotenv::create(__DIR__.'/../../../..');
-            $dotenv->load();
-        }
 
         if (!$already_loaded) {
             $modules = scandir(__DIR__.'/../../Modules');

--- a/configure_system.php
+++ b/configure_system.php
@@ -29,25 +29,6 @@ const NEW_COLOR_PRIM_BACK = 'NEW_COLOR_PRIM_BACK';
 const NEW_COLOR_SECONDARY = 'NEW_COLOR_SECONDARY';
 const NEW_COLOR_SECOND_BACK = 'NEW_COLOR_SECOND_BACK';
 
-
-function delete_files($target)
-{
-    if (is_dir($target)) {
-        $files = glob($target.'*', GLOB_MARK);
-
-        foreach ($files as $file) {
-            delete_files($file);
-        }
-
-        @rmdir($target);
-    } elseif (is_file($target)) {
-        @unlink($target);
-    }
-
-}
-
-
-require_once __DIR__."/functions/locations.inc";
 require __DIR__."/vendor/autoload.php";
 if (is_file(ENV_FILE)) {
     $dotenv = Dotenv\Dotenv::create(__DIR__);
@@ -72,6 +53,27 @@ if (is_file(ENV_FILE)) {
 } else {
     $configure = true;
 }
+
+
+function delete_files($target)
+{
+    if (is_dir($target)) {
+        $files = glob($target.'*', GLOB_MARK);
+
+        foreach ($files as $file) {
+            delete_files($file);
+        }
+
+        @rmdir($target);
+    } elseif (is_file($target)) {
+        @unlink($target);
+    }
+
+}
+
+
+require_once __DIR__."/functions/locations.inc";
+
 
 if (!$configure) {
     header("Location: ".$BASEURL."/index.php?Function=public");

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     volumes:
       - .:/var/www/html/
     environment:
+        # To more nearly simulate Production, comment all but `DOCKER` out and rely on `.env`
         DBHOST: 'mysql'
         DBNAME: ${DBNAME}
         DBPASS: ${DBPASS}

--- a/index.php
+++ b/index.php
@@ -4,6 +4,12 @@
     require_module 'standard';
     require_module 'core';
 .*/
+require __DIR__."/vendor/autoload.php";
+
+if (is_file(__DIR__.'/.env')) {
+    $dotenv = Dotenv\Dotenv::create(__DIR__);
+    $dotenv->load();
+}
 
 // Start the session so we are ready to go no matter what we do!
 session_start();
@@ -17,11 +23,7 @@ require_once __DIR__.'/functions/functions.inc';
 require_once __DIR__.'/console/console.inc';
 
 
-require __DIR__."/vendor/autoload.php";
-if (is_file(__DIR__.'/.env')) {
-    $dotenv = Dotenv\Dotenv::create(__DIR__);
-    $dotenv->load();
-}
+
 
 $configure = false;
 try {


### PR DESCRIPTION
In development where we're now mostly using docker, .env isn't as crucial for setup; in production, it's absolutely required.

`Dotenv\Dotenv::create()` needs to happen before most requires in `index.php` and some other entry-point files, especially before `functions.inc` is required. This PR shifts things around to make that work.

We might want to simply pull the environment variables out of `docker-compose.yml`, to force the two environments to behave more similarly.