### PR TITLE
Hide title for narrow screens

### DIFF
--- a/pages/body/create.inc
+++ b/pages/body/create.inc
@@ -9,7 +9,7 @@
 
 <header class="w3-cell-row event-color-primary w3-mobile">
   <?php require($PAGESDIR.'/base/logo.inc'); ?>
-  <div class="w3-container w3-cell w3-mobile">
+  <div class="UI-page-title w3-container w3-cell w3-mobile">
     <h2><?php echo $CONSITENAME; ?></h2>
   </div>
 </header>

--- a/scss/common.scss
+++ b/scss/common.scss
@@ -554,6 +554,13 @@
     @extend .w3-mobile;
 }
 
+/* Hide it entirely if the screen is narrow*/
+@media screen and (max-width: 630px) {
+    .UI-page-title {
+        display: none;
+    }
+}
+
 .UI-recovery-text-block {
     @extend .UI-center;
     @extend .UI-bold;


### PR DESCRIPTION
Simple media-query tweak to hide the title when it would make the page header too tall because of wrapping.

![image](https://user-images.githubusercontent.com/1122780/117586310-14504d00-b0dd-11eb-9d77-bcb656a125fc.png)
![image](https://user-images.githubusercontent.com/1122780/117586325-2336ff80-b0dd-11eb-9cf2-4536b4d35dde.png)
