### PR TITLE
Always return a list

### DIFF
--- a/api/src/Modules/registration/Controller/Ticket/ListTickets.php
+++ b/api/src/Modules/registration/Controller/Ticket/ListTickets.php
@@ -204,19 +204,13 @@ class ListTickets extends BaseTicketInclude
         if (empty($tickets)) {
             throw new NotFoundException('Ticket Not Found');
         }
-        if (count($tickets) > 1) {
-            $output = ['type' => 'ticket_list'];
-            return [
-            \App\Controller\BaseController::LIST_TYPE,
-            $tickets,
-            $output
-            ];
-        } else {
-            return [
-            \App\Controller\BaseController::RESOURCE_TYPE,
-            $tickets[0]
-            ];
-        }
+
+        $output = ['type' => 'ticket_list'];
+        return [
+        \App\Controller\BaseController::LIST_TYPE,
+        $tickets,
+        $output
+        ];
 
     }
 


### PR DESCRIPTION
If something can ever return a list, it should always return a list, even if it's a list of 1 item. That way, parsers don't have to choose.