### PR TITLE
xdebug 2.9.0 for php7

### DIFF
--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -5,7 +5,8 @@ RUN apk update \
 RUN docker-php-ext-install mysqli pdo_mysql
 RUN docker-php-ext-install gd
 RUN apk add $PHPIZE_DEPS \
-    && pecl install xdebug \
+    && pecl channel-update pecl.php.net \
+    && pecl install xdebug-2.9.0 \
     && docker-php-ext-enable xdebug
 COPY msmtprc /.msmtprc
 COPY php.ini /usr/local/etc/php/php.ini


### PR DESCRIPTION
When starting a brand new docker instance for the project, it fails upon installing xdebug. However, since xdebug in the `dockerfile` isn't defining a version, its grabbing the latest xdebug. 

## Why is this an issue?
The lastest xdebug is built for php8. This project is running php7, and the [latest xdebug doesn't support php7](https://xdebug.org/docs/compat).

```go
pecl/xdebug requires PHP (version >= 8.0.0, version <= 8.2.99), installed version is 7.2.7'
```

## How to resolve? 
This can be resolved by defining the xdebug version that works with php7, which is xdebug 2.9. We resolve this by updating dockerfile to expecitly require 2.9.0. Upon this change, docker builds the image and runs.


## Additional reading
- [xdebug compatiblity matrix](https://xdebug.org/docs/compat)
- #596 