### PR TITLE
Continuation of ConCom Split - Add Sidebar

### DIFF
--- a/modules/concom/sitesupport/components/department-member.js
+++ b/modules/concom/sitesupport/components/department-member.js
@@ -2,7 +2,6 @@
 const PROPS = {
   staff: Object,
   isDepartment: Boolean,
-  currentUser: Object
 };
 
 const TEMPLATE = `
@@ -16,7 +15,8 @@ const TEMPLATE = `
     <p>{{staff.note}}</p>
     <p v-if="currentUser?.id === staff.id">This is you!</p>
   </div>
-  <div class="UI-table-cell-no-border"></div>
+  <div class="UI-table-cell-no-border">
+  </div>
 `;
 
 const staffFullName = (staff) => Vue.computed(() => {
@@ -50,6 +50,12 @@ const INITIAL_DATA = () => {
 const departmentMemberComponent = {
   props: PROPS,
   template: TEMPLATE,
+  setup() {
+    const currentUser = Vue.inject('currentUser');
+    return {
+      currentUser: currentUser.value
+    }
+  },
   data: INITIAL_DATA
 };
 

--- a/modules/concom/sitesupport/components/staff-department.js
+++ b/modules/concom/sitesupport/components/staff-department.js
@@ -3,8 +3,7 @@ import { extractDepartmentStaff } from '../department-staff-parser.js';
 
 const PROPS = {
   department: Object,
-  division: Object,
-  currentUser: Object
+  division: Object
 }
 
 const TEMPLATE = `
@@ -22,7 +21,7 @@ const TEMPLATE = `
   <div :class="tableClass(department).value">
     <department-header :isDepartment=isDepartment(department).value :department=department></department-header>
     <div class="UI-table-row" v-for="staff in departmentStaff">
-      <department-member :staff=staff :isDepartment=isDepartment(department).value :currentUser=currentUser></department-member>
+      <department-member :staff=staff :isDepartment=isDepartment(department).value></department-member>
     </div>
   </div>
 `;

--- a/modules/concom/sitesupport/components/staff-division.js
+++ b/modules/concom/sitesupport/components/staff-division.js
@@ -1,8 +1,6 @@
 /* globals Vue */
 const PROPS = {
-  division: Object,
-  divisionHierarchy: Array,
-  currentUser: Object
+  division: Object
 };
 
 const TEMPLATE = `
@@ -11,14 +9,14 @@ const TEMPLATE = `
       <div class="UI-table-row event-color-secondary">
         <div class="UI-center UI-table-cell-no-border">{{divisionName(division).value}}</div>
         <div class="UI-center UI-table-cell-no-border">
-          <staff-section-nav :divisionContent=divisionHierarchy :id="htmlTagFriendlyName(division).value + '_nav'"></staff-section-nav>
+          <staff-section-nav :id="htmlTagFriendlyName(division).value + '_nav'"></staff-section-nav>
         </div>
         <div class="UI-table-cell-no-border">
           <template v-for="email in division.email">{{email}}<br/></template>
         </div> 
       </div>
     </div>
-    <staff-department :department=division :division=division :currentUser=currentUser></staff-department>
+    <staff-department :department=division :division=division></staff-department>
     <div class="UI-container UI-padding">
       <template v-for="department in division.departments">
         <staff-department :department=department :division=division></staff-department>

--- a/modules/concom/sitesupport/components/staff-list.js
+++ b/modules/concom/sitesupport/components/staff-list.js
@@ -1,13 +1,17 @@
 /* globals apiRequest, Vue */
 import { extractDivisionHierarchy } from '../division-parser.js';
 
+const SUBHEAD_POSITION_ID = 2;
+
 const TEMPLATE = `
-  <div class="UI-maincontent">
+  <div :class="contentAreaClass(showSidebar).value">
     <div class="UI-event-sectionbar">ConCom</div>
     <div class="UI-maincontent">
       <staff-division v-for="division in divisions" :division=division></staff-division>
     </div>
   </div>
+  <staff-sidebar v-if="showSidebar" :department=sidebarDept :isDepartment=sidebarDeptIsDepartment 
+    @sidebar-closed="closeSidebar" @sidebar-form-submitted="updateDepartment"></staff-sidebar>
 `;
 
 const fetchDivisionData = async() => {
@@ -24,31 +28,101 @@ const fetchCurrentUser = async() => {
   return {
     id: parseInt(memberData.id)
   };
+};
+
+const fetchStaffPositions = async() => {
+  const response = await apiRequest('GET', 'staff/positions');
+  const positionData = JSON.parse(response.responseText);
+
+  const positionMapping = positionData.data.reduce((prev, current) => {
+    const mappedPosition = {
+      id: parseInt(current.id),
+      name: current.position
+    };
+
+    if (mappedPosition.id !== SUBHEAD_POSITION_ID) {
+      prev.divisionPositions.push(mappedPosition);
+    }
+
+    prev.departmentPositions.push(mappedPosition);
+    return prev;
+  }, {
+    departmentPositions: [],
+    divisionPositions: []
+  });
+
+  return positionMapping;
 }
 
 const onMounted = async(componentInstance) => {
-  const result = await fetchDivisionData();
-  componentInstance.divisions.push(...result);
+  // Make sure we have all of the data we need before allowing child component rendering.
+  const [divisionResult, userResult, positionResult] = await Promise.all([
+    fetchDivisionData(),
+    fetchCurrentUser(),
+    fetchStaffPositions()
+  ]);
 
-  const userResult = await fetchCurrentUser();
+  componentInstance.divisions.push(...divisionResult);
   componentInstance.currentUser = userResult;
+  componentInstance.staffPositions = positionResult;
 };
+
+function componentSetup() {
+  const currentUser = Vue.ref({ id: null });
+  Vue.provide('currentUser', Vue.readonly(currentUser));
+
+  const divisions = Vue.ref([]);
+  Vue.provide('divisions', Vue.readonly(divisions));
+
+  const staffPositions = Vue.ref({ departmentPositions: [], divisionPositions: [] });
+  Vue.provide('staffPositions', Vue.readonly(staffPositions));
+
+  const showSidebar = Vue.ref(false);
+  Vue.provide('showSidebar', showSidebar);
+
+  const sidebarDept = Vue.ref({});
+  Vue.provide('sidebarDept', sidebarDept);
+
+  const sidebarDeptStaff = Vue.ref([]);
+  Vue.provide('sidebarDeptStaff', sidebarDeptStaff);
+
+  const sidebarDeptIsDepartment = Vue.ref(false);
+  Vue.provide('sidebarDeptIsDepartment', sidebarDeptIsDepartment);
+  return {
+    currentUser,
+    divisions,
+    staffPositions,
+    showSidebar,
+    sidebarDept,
+    sidebarDeptStaff,
+    sidebarDeptIsDepartment
+  }
+}
+
+const contentAreaClass = (showSidebar) => Vue.computed(() => {
+  return showSidebar ? 'UI-maincontent UI-mainsection-sidebar-shown' : 'UI-maincontent UI-rest';
+});
+
+function closeSidebar() {
+  this.showSidebar = false;
+}
+
+function updateDepartment(eventData) {
+  if (eventData.eventType === 'added') {
+    this.sidebarDeptStaff.push(eventData.staff);
+  }
+}
 
 const staffListComponent = {
   template: TEMPLATE,
-  setup() {
-    const currentUser = Vue.ref({ id: null });
-    Vue.provide('currentUser', Vue.readonly(currentUser));
-
-    const divisions = Vue.ref([]);
-    Vue.provide('divisions', Vue.readonly(divisions));
-    return {
-      currentUser,
-      divisions
-    }
-  },
+  setup: componentSetup,
   async mounted() {
     await onMounted(this);
+  },
+  methods: {
+    contentAreaClass,
+    closeSidebar,
+    updateDepartment
   }
 };
 

--- a/modules/concom/sitesupport/components/staff-list.js
+++ b/modules/concom/sitesupport/components/staff-list.js
@@ -1,15 +1,14 @@
-/* globals apiRequest */
+/* globals apiRequest, Vue */
 import { extractDivisionHierarchy } from '../division-parser.js';
 
 const TEMPLATE = `
-  <staff-division v-for="division in divisionHierarchy" :division=division 
-    :divisionHierarchy=divisionHierarchy :currentUser=currentUser></staff-division>
+  <div class="UI-maincontent">
+    <div class="UI-event-sectionbar">ConCom</div>
+    <div class="UI-maincontent">
+      <staff-division v-for="division in divisions" :division=division></staff-division>
+    </div>
+  </div>
 `;
-
-const INITIAL_DATA = {
-  divisionHierarchy: [],
-  currentUser: undefined
-};
 
 const fetchDivisionData = async() => {
   const response = await apiRequest('GET', 'department');
@@ -29,18 +28,24 @@ const fetchCurrentUser = async() => {
 
 const onMounted = async(componentInstance) => {
   const result = await fetchDivisionData();
-  componentInstance.divisionHierarchy.push(...result);
+  componentInstance.divisions.push(...result);
 
   const userResult = await fetchCurrentUser();
-  componentInstance.currentUser = {
-    ...userResult
-  };
+  componentInstance.currentUser = userResult;
 };
 
 const staffListComponent = {
   template: TEMPLATE,
-  data() {
-    return INITIAL_DATA
+  setup() {
+    const currentUser = Vue.ref({ id: null });
+    Vue.provide('currentUser', Vue.readonly(currentUser));
+
+    const divisions = Vue.ref([]);
+    Vue.provide('divisions', Vue.readonly(divisions));
+    return {
+      currentUser,
+      divisions
+    }
   },
   async mounted() {
     await onMounted(this);

--- a/modules/concom/sitesupport/components/staff-section-nav.js
+++ b/modules/concom/sitesupport/components/staff-section-nav.js
@@ -1,8 +1,4 @@
 /* globals Vue */
-const PROPS = {
-  divisionContent: Array
-};
-
 const TEMPLATE = `
   <div class="CONCOM-goto-dropdown">
     Go To Section
@@ -24,8 +20,13 @@ const INITIAL_DATA = () => {
 };
 
 const sectionNavComponent = {
-  props: PROPS,
   template: TEMPLATE,
+  setup() {
+    const divisions = Vue.inject('divisions');
+    return {
+      divisionContent: divisions.value
+    }
+  },
   data: INITIAL_DATA
 };
 

--- a/modules/concom/sitesupport/components/staff-sidebar.js
+++ b/modules/concom/sitesupport/components/staff-sidebar.js
@@ -1,0 +1,125 @@
+/* globals Vue, apiRequest */
+const PROPS = {
+  department: Object,
+  isDepartment: Boolean
+};
+
+const DIRECTOR_POSITION_ID = 1;
+
+const TEMPLATE = `
+  <div class="UI-sidebar-shown UI-fixed">
+    <div class="UI-center">
+      <h2 class="UI-red">Add to {{ getHeaderText(isDepartment).value }}</h2>
+    </div>
+    <div class="UI-center">
+      <label class="UI-label" for="concom_lookup">
+        <h2>Add someone to {{ department.name }}</h2>
+      </label>
+      <fieldset>
+        <legend>Search the User Database</legend>
+        <div class="UI-rest UI-center" id="concom_lookup">
+          <lookup-user @handler="onUserLookup"></lookup-user>
+        </div>
+      </fieldset>
+      <p>
+        <label class="UI-label" for="position">Position:</label>
+        <select v-model="selectedPosition">
+          <option disabled value="">Please select a position</option>
+          <option v-for="position in availablePositions(staffPositions, isDepartment).value" :key=position.id :value=position>
+            {{position.name}}
+          </option>
+        </select>
+      </p>
+    </div>
+    <div class="UI-center UI-padding">
+      <button class="UI-eventbutton" :disabled="disableForm(userId, selectedPosition).value" @click="onSubmit">OK</button>
+      <button class="UI-redbutton" @click="$emit('sidebarClosed')">Close</button>
+    </div>
+  </div>
+`;
+
+const availablePositions = (staffPositions, isDepartment) => Vue.computed(() => {
+  if (isDepartment) {
+    return staffPositions.departmentPositions
+  }
+
+  return staffPositions.divisionPositions.map(position => {
+    return {
+      id: position.id,
+      name: position.id === DIRECTOR_POSITION_ID ? 'Director' : 'Support'
+    }
+  })
+});
+
+const getHeaderText = (isDepartment) => Vue.computed(() => {
+  return isDepartment ? 'Department' : 'Division';
+});
+
+const disableForm = (userId, position) => Vue.computed(() => {
+  return userId === null || (position === '' || position?.id === null);
+});
+
+function onUserLookup(_, item) {
+  this.userId = item.Id;
+}
+
+async function onSubmit() {
+  const postData = {
+    Department: this.department.id,
+    Position: this.selectedPosition.id
+  };
+
+  const staffUpdateResponse = await apiRequest('POST', `member/${this.userId}/staff_membership`,
+    `Department=${postData.Department}&Position=${postData.Position}`);
+
+  if (staffUpdateResponse.status === 201) {
+    const staffResponse = await apiRequest('GET', `member/${this.userId}`);
+    const staff = JSON.parse(staffResponse.responseText);
+    const emittedEventData = {
+      staff: {
+        departmentName: this.department.name,
+        firstName: staff.first_name,
+        lastName: staff.last_name,
+        pronouns: staff.pronouns,
+        position: this.selectedPosition.name,
+        email: staff.email
+      },
+      departmentId: this.department.id,
+      eventType: 'added'
+    };
+
+    this.$emit('sidebarFormSubmitted', emittedEventData);
+  }
+}
+
+const INITIAL_DATA = () => {
+  return {
+    userId: null,
+    selectedPosition: Vue.ref('')
+  }
+};
+
+function componentSetup() {
+  const staffPositions = Vue.inject('staffPositions');
+
+  return {
+    staffPositions
+  }
+}
+
+const staffSidebarComponent = {
+  props: PROPS,
+  emits: ['sidebarClosed', 'sidebarFormSubmitted'],
+  data: INITIAL_DATA,
+  template: TEMPLATE,
+  setup: componentSetup,
+  methods: {
+    onUserLookup,
+    onSubmit,
+    availablePositions,
+    disableForm,
+    getHeaderText
+  }
+};
+
+export default staffSidebarComponent;

--- a/modules/concom/sitesupport/concom_v2.js
+++ b/modules/concom/sitesupport/concom_v2.js
@@ -5,6 +5,8 @@
 // import departmentHeaderComponent from './components/department-header.js';
 // import departmentMemberComponent from './components/department-member.js';
 // import staffDepartmentComponent from './components/staff-department.js';
+// import staffSidebarComponent from './components/staff-sidebar.js';
+// import lookupuser from '../../../sitesupport/vue/lookupuser.js';
 
 const staffApp = Vue.createApp({});
 
@@ -14,6 +16,8 @@ const staffApp = Vue.createApp({});
 // staffApp.component('department-header', departmentHeaderComponent);
 // staffApp.component('department-member', departmentMemberComponent);
 // staffApp.component('staff-department', staffDepartmentComponent);
+// staffApp.component('staff-sidebar', staffSidebarComponent);
+// staffApp.component('lookup-user', lookupuser);
 
 // staffApp.mount('#staff-app');
 


### PR DESCRIPTION
This PR includes:
- Some cleanup to avoid "prop drilling" (https://vuejs.org/guide/components/provide-inject.html)
- Wires up functionality for clicking on "Add someone to <department or division>", which includes the sidebar and ability to add members only (for now)
- Making use of the new staff positions API

Would like to revisit in the future after we have reached feature parity with existing sidebar implementation. Feature parity for adding was achieved but is a little messy due to providing and injecting extra properties to facilitate allowing the UI to handle the updates without reloading from the server. More details on implementation specifics below.

For example, because the sidebar must be rendered at the same level as "staff list", we cannot easily or simply just emit events from the sidebar that impact _only_ the department component where "Add someone" was clicked.

Ideally, clicking "Add someone" would allow us to render something on the screen that can be referenced by the department component so we can emit events more easily, allowing us to easily modify the staff list as appropriate when adding staff (or making other changes, in the future). 

For now, this behavior is achieved by having the department component assign its staff to an injected property from the staff list component, which allows the staff list component to respond to the events emitted by the sidebar and modify the department staff accordingly, although this is slightly confusing.

If testing in your own UI, you will need to remove the entire contents of `modules/concom/pages/body.inc` and then add:
```
<div id="staff-app">
  <staff-list></staff-list>
</div>
```

In addition, you will need to uncomment the imports and components in `modules/concom/sitesupport/concom_v2.js` and comment out lines 14 and 15 in `modules/concom/sitesupport/vue.js`, or the sidebar rendering will not display correctly due to the existing HTML being present.