### PR TITLE
api: refine the staff listing methods

### DIFF
--- a/api/src/Modules/staff/App/Routes.php
+++ b/api/src/Modules/staff/App/Routes.php
@@ -18,6 +18,7 @@ function setupStaffAPI($app, $authMiddleware)
     $app->group(
         '/staff',
         function () use ($app, $authMiddleware) {
+            $app->get('[/]', 'App\Modules\staff\Controller\ListStaff');
             $app->get('/membership/{id}', 'App\Modules\staff\Controller\GetStaffMembership');
             $app->delete('/membership/{id}', 'App\Modules\staff\Controller\DeleteStaffMembership');
             $app->get('/positions', 'App\Modules\staff\Controller\ListStaffPositions');
@@ -27,8 +28,7 @@ function setupStaffAPI($app, $authMiddleware)
     $app->group(
         '/department',
         function () use ($app, $authMiddleware) {
-            $app->get('/staff/', 'App\Modules\staff\Controller\ListStaff');
-            $app->get('/{id}/staff', 'App\Modules\staff\Controller\GetDepartment');
+            $app->get('/{id}/staff', 'App\Modules\staff\Controller\ListDepartmentStaff');
         }
     )->add(new App\Middleware\CiabMiddleware($app))->add($authMiddleware);
 

--- a/api/src/Modules/staff/Controller/BaseStaff.php
+++ b/api/src/Modules/staff/Controller/BaseStaff.php
@@ -169,7 +169,7 @@ abstract class BaseStaff extends BaseController
     }
 
 
-    protected function selectStaff($event, $department = null, $member = null)
+    protected function selectStaff($event, $department = null, $member = null, $include_subdep = false)
     {
         $select = Select::new($this->container->db);
 
@@ -217,6 +217,17 @@ abstract class BaseStaff extends BaseController
         if ($department !== null) {
             $department = $this->getDepartment($department);
             $select->where('l.DepartmentID = ', $department['id']);
+            if ($include_subdep) {
+                $subdeps = $select->subselect()->columns(
+                    'DepartmentID'
+                )->from(
+                    'Departments'
+                )->where(
+                    "ParentDepartmentID = ",
+                    $department['id']
+                );
+                $select->orWhere('l.DepartmentID IN ', $subdeps);
+            }
         }
 
         if ($member !== null) {

--- a/api/src/Modules/staff/Controller/ListDepartmentStaff.php
+++ b/api/src/Modules/staff/Controller/ListDepartmentStaff.php
@@ -16,6 +16,18 @@
  *          @OA\Schema(type="integer")
  *      ),
  *      @OA\Parameter(
+ *          parameter="subdepartments",
+ *          description="include sub-departments",
+ *          in="query",
+ *          name="subdepartments",
+ *          required=false,
+ *          style="form",
+ *          @OA\Schema(
+ *              type="integer",
+ *              enum={0, 1}
+ *          )
+ *      ),
+ *      @OA\Parameter(
  *          ref="#/components/parameters/event",
  *      ),
  *      @OA\Parameter(
@@ -55,7 +67,7 @@ namespace App\Modules\staff\Controller;
 use Slim\Http\Request;
 use Slim\Http\Response;
 
-class GetDepartment extends BaseStaff
+class ListDepartmentStaff extends BaseStaff
 {
 
 
@@ -64,7 +76,8 @@ class GetDepartment extends BaseStaff
         $permissions = ['api.get.staff'];
         $this->checkPermissions($permissions);
         $event = $this->getEventId($request);
-        $data = $this->selectStaff($event, $params['id']);
+        $sub = boolval($request->getQueryParam('subdepartments', 0));
+        $data = $this->selectStaff($event, $params['id'], null, $sub);
         return [
         \App\Controller\BaseController::LIST_TYPE,
         $data,
@@ -74,5 +87,5 @@ class GetDepartment extends BaseStaff
     }
 
 
-    /* end GetDepartment */
+    /* end ListDepartmentStaff */
 }

--- a/api/src/Modules/staff/Controller/ListStaff.php
+++ b/api/src/Modules/staff/Controller/ListStaff.php
@@ -6,7 +6,7 @@
 /**
  *  @OA\Get(
  *      tags={"departments"},
- *      path="/department/staff/",
+ *      path="/staff",
  *      summary="List staff all departments",
  *      @OA\Parameter(
  *          ref="#/components/parameters/event",

--- a/api/src/Tests/Cases/StaffTest.php
+++ b/api/src/Tests/Cases/StaffTest.php
@@ -25,7 +25,7 @@ class StaffTest extends CiabTestCase
 
     public function testMembership(): void
     {
-        $position = $this->runSuccessJsonRequest('POST', '/member/1000/staff_membership', null, ['Department' => '2', 'Position' => '1', 'Note' => 'PHPUnit Testing'], 201);
+        $position = $this->runSuccessJsonRequest('POST', '/member/1000/staff_membership', null, ['Department' => '102', 'Position' => '1', 'Note' => 'PHPUnit Testing'], 201);
         $this->assertNotEmpty($position);
 
         $data = $this->runSuccessJsonRequest('GET', '/member/1000/staff_membership');
@@ -42,11 +42,21 @@ class StaffTest extends CiabTestCase
         $data = $this->runSuccessJsonRequest('GET', '/staff/membership/'.$position->id);
         $this->assertNotEmpty($data);
 
-        $data = $this->runSuccessJsonRequest('GET', '/department/staff/');
+        $data = $this->runSuccessJsonRequest('GET', '/staff');
         $this->assertNotEmpty($data);
+        $this->assertNotEmpty($data->data);
 
-        $data = $this->runSuccessJsonRequest('GET', '/department/1/staff');
+        $data = $this->runSuccessJsonRequest('GET', '/department/102/staff');
         $this->assertNotEmpty($data);
+        $this->assertNotEmpty($data->data);
+
+        $data = $this->runSuccessJsonRequest('GET', '/department/2/staff');
+        $this->assertNotEmpty($data);
+        $this->assertEmpty($data->data);
+
+        $data = $this->runSuccessJsonRequest('GET', '/department/2/staff', ['subdepartments' => 1]);
+        $this->assertNotEmpty($data);
+        $this->assertNotEmpty($data->data);
 
         $this->runRequest('DELETE', '/staff/membership/'.$position->id, null, null, 204);
 

--- a/ciab.openapi.yaml
+++ b/ciab.openapi.yaml
@@ -2676,45 +2676,6 @@ paths:
       security:
         -
           ciab_auth: []
-  '/department/{id}/staff':
-    get:
-      tags:
-        - departments
-      summary: 'List staff for a department'
-      parameters:
-        -
-          name: id
-          in: path
-          description: 'Department being listed'
-          required: true
-          schema:
-            type: integer
-        -
-          $ref: '#/components/parameters/event'
-        -
-          $ref: '#/components/parameters/short_response'
-        -
-          $ref: '#/components/parameters/max_results'
-        -
-          $ref: '#/components/parameters/page_token'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/staff_list'
-        '401':
-          $ref: '#/components/responses/401'
-        '404':
-          description: 'Event or Department not found in the system.'
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/error'
-      security:
-        -
-          ciab_auth: []
   '/member/{id}/staff_membership':
     get:
       tags:
@@ -2774,7 +2735,58 @@ paths:
       security:
         -
           ciab_auth: []
-  /department/staff/:
+  '/department/{id}/staff':
+    get:
+      tags:
+        - departments
+      summary: 'List staff for a department'
+      parameters:
+        -
+          name: id
+          in: path
+          description: 'Department being listed'
+          required: true
+          schema:
+            type: integer
+        -
+          parameter: subdepartments
+          name: subdepartments
+          in: query
+          description: 'include sub-departments'
+          required: false
+          style: form
+          schema:
+            type: integer
+            enum:
+              - 0
+              - 1
+        -
+          $ref: '#/components/parameters/event'
+        -
+          $ref: '#/components/parameters/short_response'
+        -
+          $ref: '#/components/parameters/max_results'
+        -
+          $ref: '#/components/parameters/page_token'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/staff_list'
+        '401':
+          $ref: '#/components/responses/401'
+        '404':
+          description: 'Event or Department not found in the system.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error'
+      security:
+        -
+          ciab_auth: []
+  /staff:
     get:
       tags:
         - departments


### PR DESCRIPTION
* Move /department/staff to /staff as it lists all staff regardless of department.
* Rename `GetDepartment` to `ListDepartmentStaff` as it is much more descriptive and correct
* add `subdepartments` parameter to `ListDepartmentStaff` to list staff in sub-departments of that department (division) is requested