### PR TITLE
Ryan/concom sidebar

### DIFF
--- a/api/src/Modules/staff/App/Routes.php
+++ b/api/src/Modules/staff/App/Routes.php
@@ -12,6 +12,7 @@ function setupStaffAPI($app, $authMiddleware)
             $app->get('/staff_membership/', 'App\Modules\staff\Controller\GetMemberPosition');
             $app->get('/{id}/staff_membership', 'App\Modules\staff\Controller\GetMemberPosition');
             $app->post('/{id}/staff_membership', 'App\Modules\staff\Controller\PostStaffMembership');
+            $app->put('/{id}/staff_membership', 'App\Modules\staff\Controller\PutStaffMembership');
         }
     )->add(new App\Middleware\CiabMiddleware($app))->add($authMiddleware);
 

--- a/api/src/Modules/staff/Controller/PutStaffMembership.php
+++ b/api/src/Modules/staff/Controller/PutStaffMembership.php
@@ -1,0 +1,102 @@
+<?php declare(strict_types=1);
+/*.
+    require_module 'standard';
+.*/
+
+/**
+ *  @OA\Put(
+ *      tags={"members"},
+ *      path="/member/{id}/staff_membership",
+ *      summary="Update a staff membership for the member",
+ *      @OA\Parameter(
+ *          description="The ID of the member",
+ *          in="path",
+ *          name="id",
+ *          required=true,
+ *          @OA\Schema(
+ *              description="Member ID",
+ *              type="integer"
+ *          )
+ *      ),
+ *      @OA\RequestBody(
+ *          @OA\MediaType(
+ *              mediaType="application/x-www-form-urlencoded",
+ *              @OA\Schema(
+ *                  @OA\Property(
+ *                      property="Department",
+ *                      description="ID or name of the department",
+ *                      nullable=false,
+ *                      type="string"
+ *                  ),
+ *                  @OA\Property(
+ *                      property="Position",
+ *                      description="ID of the position",
+ *                      nullable=false,
+ *                      type="integer"
+ *                  ),
+ *                  @OA\Property(
+ *                      property="Note",
+ *                      description="Notes about member",
+ *                      nullable=true,
+ *                      type="string"
+ *                  )
+ *              )
+ *          )
+ *      ),
+ *      @OA\Response(
+ *          response=200,
+ *          description="OK"
+ *      ),
+ *      @OA\Response(
+ *          response=401,
+ *          ref="#/components/responses/401"
+ *      ),
+ *      security={{"ciab_auth":{}}}
+ *  )
+ */
+
+
+namespace App\Modules\staff\Controller;
+
+use Slim\Http\Request;
+use Slim\Http\Response;
+use App\Controller\InvalidParameterException;
+use Atlas\Query\Update;
+
+class PutStaffMembership extends BaseStaff
+{
+
+
+    public function buildResource(Request $request, Response $response, $params): array
+    {
+        $body = $request->getParsedBody();
+        if (!$body) {
+            throw new InvalidParameterException('Body required');
+        }
+
+        $required = ['Department', 'Position'];
+        $this->checkRequiredBody($request, $required);
+
+        $department = $this->getDepartment($body['Department']);
+        $permissions = ['api.put.staff.'.$department['id'], 'api.put.staff.all'];
+        $this->checkPermissions($permissions);
+
+        $update = Update::new($this->container->db)
+        ->table('ConComList')
+        ->column('PositionID', $body['Position']);
+
+        if (array_key_exists('Note', $body)) {
+            $note = $body['Note'];
+            $update->column('Note', $note);
+        }
+
+        $update->WhereEquals(['AccountID' => $params['id'], 'DepartmentID' => $department['id']]);
+        $update->perform();
+
+        return [null];
+
+    }
+
+    
+    /* end PutStaffMembership */
+}

--- a/api/src/Tests/Cases/StaffTest.php
+++ b/api/src/Tests/Cases/StaffTest.php
@@ -22,6 +22,20 @@ class StaffTest extends CiabTestCase
 
     }
 
+    
+    public function testPutMembership(): void
+    {   
+        $this->runRequest('PUT', '/member/1000/staff_membership', null, null, 400);
+        $this->runRequest('PUT', '/member/-1/staff_membership', null, null, 400);
+        $this->runRequest('PUT', '/member/1000/staff_membership', null, ['Nothing' => 0], 400);
+        $this->runRequest('PUT', '/member/1000/staff_membership', null, ['Department' => -1, 'Position' => 1], 404);
+        $this->runRequest('PUT', '/member/1000/staff_membership', null, ['Department' => 1], 400);    
+        $this->runRequest('PUT', '/member/1000/staff_membership', null, ['Department' => 1, 'Position' => 1, 'Note' => 'phpunitAddedNote'], 200);
+        $data = $this->runSuccessJsonRequest('GET', '/member/1000/staff_membership');
+        $this->assertEquals($data->data[0]->position, 'Head');
+        $this->assertEquals($data->data[0]->note, 'phpunitAddedNote');
+    }
+
 
     public function testMembership(): void
     {

--- a/ciab.openapi.yaml
+++ b/ciab.openapi.yaml
@@ -2738,6 +2738,45 @@ paths:
       security:
         -
           ciab_auth: []
+    put:
+      tags:
+        - members
+      summary: 'Update a staff membership for the member'
+      parameters:
+        -
+          name: id
+          in: path
+          description: 'The ID of the member'
+          required: true
+          schema:
+            description: 'Member ID'
+            type: integer
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              properties:
+                Department:
+                  nullable: false
+                  description: 'ID or name of the department'
+                  type: string
+                Position:
+                  nullable: false
+                  description: 'ID of the position'
+                  type: integer
+                Note:
+                  nullable: true
+                  description: 'Notes about member'
+                  type: string
+              type: object
+      responses:
+        '200':
+          description: OK
+        '401':
+          $ref: '#/components/responses/401'
+      security:
+        -
+          ciab_auth: []
   /member/staff_membership/:
     get:
       tags:

--- a/modules/concom/sitesupport/components/department-member.js
+++ b/modules/concom/sitesupport/components/department-member.js
@@ -2,6 +2,7 @@
 const PROPS = {
   staff: Object,
   isDepartment: Boolean,
+  canEdit: Boolean
 };
 
 const TEMPLATE = `
@@ -16,6 +17,8 @@ const TEMPLATE = `
     <p v-if="currentUser?.id === staff.id">This is you!</p>
   </div>
   <div class="UI-table-cell-no-border">
+    <button class="UI-redbutton" 
+      v-if="currentUser?.editAnyAllowed || (canEdit && currentUser?.id !== staff.id)" @click="onEditClicked">Edit</button>
   </div>
 `;
 
@@ -39,6 +42,15 @@ const staffPosition = (staff, isDepartment) => Vue.computed(() => {
   return staff.position;
 });
 
+function onEditClicked() {
+  const emittedEventData = {
+    staff: this.staff,
+    isDepartment: this.isDepartment
+  };
+
+  this.$emit('editClicked', emittedEventData);
+}
+
 const INITIAL_DATA = () => {
   return {
     staffFullName,
@@ -50,13 +62,17 @@ const INITIAL_DATA = () => {
 const departmentMemberComponent = {
   props: PROPS,
   template: TEMPLATE,
+  emits: [ 'editClicked' ],
   setup() {
     const currentUser = Vue.inject('currentUser');
     return {
-      currentUser: currentUser.value
+      currentUser
     }
   },
-  data: INITIAL_DATA
+  data: INITIAL_DATA,
+  methods: {
+    onEditClicked
+  }
 };
 
 export default departmentMemberComponent;

--- a/modules/concom/sitesupport/components/staff-sidebar.js
+++ b/modules/concom/sitesupport/components/staff-sidebar.js
@@ -1,17 +1,12 @@
 /* globals Vue, apiRequest */
-const PROPS = {
-  department: Object,
-  isDepartment: Boolean
-};
-
 const DIRECTOR_POSITION_ID = 1;
 
 const TEMPLATE = `
   <div class="UI-sidebar-shown UI-fixed">
     <div class="UI-center">
-      <h2 class="UI-red">Add to {{ getHeaderText(isDepartment).value }}</h2>
+      <h2 class="UI-red">{{ getHeaderText(isEdit, isDepartment).value }}</h2>
     </div>
-    <div class="UI-center">
+    <div class="UI-center" v-if="!isEdit">
       <label class="UI-label" for="concom_lookup">
         <h2>Add someone to {{ department.name }}</h2>
       </label>
@@ -31,9 +26,25 @@ const TEMPLATE = `
         </select>
       </p>
     </div>
+    <template v-if="isEdit">
+      <div>
+        <h3 class="UI-center">{{ getStaffFullName(editStaff).value }}</h3>
+        <h4 class="UI-center">{{ getStaffPosition(editStaff, isDepartment).value }} in {{ department.name }}</h4>
+        <label class="UI-label" for="user_notes">Note</label>
+        <input class="UI-input" id="user_notes" v-model="staffNote"/>
+        <br/>
+        <label class="UI-label" for="user_pos">Position: </label>
+        <select v-model="selectedPosition">
+          <option v-for="position in availablePositions(staffPositions, isDepartment).value" :key=position.id :value=position>
+            {{position.name}}
+          </option>
+        </select>
+      </div>
+    </template>
     <div class="UI-center UI-padding">
       <button class="UI-eventbutton" :disabled="disableForm(userId, selectedPosition).value" @click="onSubmit">OK</button>
-      <button class="UI-redbutton" @click="$emit('sidebarClosed')">Close</button>
+      <button class="UI-redbutton" v-if="isEdit" @click="onRemoveStaff">Remove</button>
+      <button :class="getCloseButtonClass(isEdit).value" @click="$emit('sidebarClosed')">Close</button>
     </div>
   </div>
 `;
@@ -51,8 +62,33 @@ const availablePositions = (staffPositions, isDepartment) => Vue.computed(() => 
   })
 });
 
-const getHeaderText = (isDepartment) => Vue.computed(() => {
-  return isDepartment ? 'Department' : 'Division';
+const getCloseButtonClass = (isEdit) => Vue.computed(() => {
+  return isEdit ? 'UI-yellowbutton' : 'UI-redbutton'
+});
+
+const getHeaderText = (isEdit, isDepartment) => Vue.computed(() => {
+  if (isEdit) {
+    return 'Modify Membership';
+  }
+
+  const deptText = isDepartment ? 'Department' : 'Division';
+  return `Add to ${deptText}`;
+});
+
+const getStaffFullName = (staff) => Vue.computed(() => {
+  return `${staff.firstName} ${staff.lastName}`;
+});
+
+const getStaffPosition = (staff, isDepartment) => Vue.computed(() => {
+  if (!isDepartment) {
+    if (staff.position === 'Head') {
+      return 'Director';
+    } else if (staff.position === 'Specialist') {
+      return 'Support';
+    }
+  }
+
+  return staff.position;
 });
 
 const disableForm = (userId, position) => Vue.computed(() => {
@@ -64,28 +100,79 @@ function onUserLookup(_, item) {
 }
 
 async function onSubmit() {
-  const postData = {
-    Department: this.department.id,
-    Position: this.selectedPosition.id
+  if (this.isEdit) {
+    await editStaff(this);
+  } else {
+    await addStaff(this);
+  }
+}
+
+async function editStaff(component) {
+  const putData = {
+    Department: component.department.id,
+    Position: component.selectedPosition.id,
+    Note: component.staffNote
   };
 
-  const staffUpdateResponse = await apiRequest('POST', `member/${this.userId}/staff_membership`,
-    `Department=${postData.Department}&Position=${postData.Position}`);
+  const staffUpdateResponse = await apiRequest('PUT', `member/${component.userId}/staff_membership`,
+    `Department=${putData.Department}&Position=${putData.Position}&Note=${putData.Note}`);
 
-  if (staffUpdateResponse.status === 201) {
-    const staffResponse = await apiRequest('GET', `member/${this.userId}`);
-    const staff = JSON.parse(staffResponse.responseText);
+  if (staffUpdateResponse.status === 200) {
     const emittedEventData = {
       staff: {
-        departmentName: this.department.name,
-        firstName: staff.first_name,
-        lastName: staff.last_name,
-        pronouns: staff.pronouns,
-        position: this.selectedPosition.name,
-        email: staff.email
+        ...component.editStaff,
+        position: component.selectedPosition.name,
+        note: component.staffNote
       },
-      departmentId: this.department.id,
-      eventType: 'added'
+      eventType: 'updated'
+    };
+
+    component.$emit('sidebarFormSubmitted', emittedEventData);
+  }
+}
+
+async function addStaff(component) {
+  const postData = {
+    Department: component.department.id,
+    Position: component.selectedPosition.id
+  };
+
+  const staffAddResponse = await apiRequest('POST', `member/${component.userId}/staff_membership`,
+    `Department=${postData.Department}&Position=${postData.Position}`);
+
+  if (staffAddResponse.status === 201) {
+    const staffData = JSON.parse(staffAddResponse.responseText);
+    if (staffData) {
+      const emittedEventData = {
+        staff: {
+          id: component.userId,
+          deptStaffId: parseInt(staffData.id),
+          departmentName: component.department.name,
+          divisionName: component.division.name,
+          firstName: staffData.member.first_name,
+          lastName: staffData.member.last_name,
+          pronouns: staffData.member.pronouns,
+          position: component.selectedPosition.name,
+          email: staffData.member.email,
+          note: staffData.member.note
+        },
+        departmentId: component.department.id,
+        eventType: 'added'
+      }
+
+      component.$emit('sidebarFormSubmitted', emittedEventData);
+    }
+  }
+}
+
+async function onRemoveStaff() {
+  const staffDeleteResponse = await apiRequest('DELETE', `staff/membership/${this.deptStaffId}`);
+
+  if (staffDeleteResponse.status === 204) {
+    const emittedEventData = {
+      staff: this.editStaff,
+      department: this.department,
+      eventType: 'removed'
     };
 
     this.$emit('sidebarFormSubmitted', emittedEventData);
@@ -95,30 +182,73 @@ async function onSubmit() {
 const INITIAL_DATA = () => {
   return {
     userId: null,
+    deptStaffId: null,
     selectedPosition: Vue.ref('')
   }
 };
 
 function componentSetup() {
   const staffPositions = Vue.inject('staffPositions');
+  const staffNote = Vue.ref('');
+  const isEdit = Vue.ref(false);
+
+  const department = Vue.inject('sidebarDept');
+  const division = Vue.inject('sidebarDivision');
+  const departmentStaff = Vue.inject('sidebarDeptStaff');
+  const isDepartment = Vue.inject('sidebarDeptIsDepartment');
+  const editStaff = Vue.inject('sidebarEditStaff');
 
   return {
-    staffPositions
+    staffPositions,
+    staffNote,
+    isEdit,
+    department,
+    division,
+    departmentStaff,
+    isDepartment,
+    editStaff
   }
 }
 
 const staffSidebarComponent = {
-  props: PROPS,
   emits: ['sidebarClosed', 'sidebarFormSubmitted'],
   data: INITIAL_DATA,
   template: TEMPLATE,
   setup: componentSetup,
+  mounted() {
+    if (this.editStaff.id != null) {
+      this.userId = this.editStaff.id;
+      this.deptStaffId = this.editStaff.deptStaffId;
+      this.staffNote = this.editStaff.note;
+      this.isEdit = true;
+
+      const availablePositions = this.availablePositions(this.staffPositions, this.isDepartment).value;
+      let positionToFind = this.editStaff.position;
+
+      if (!this.isDepartment) {
+        if (this.editStaff.position === 'Head') {
+          positionToFind = 'Director';
+        } else if (this.editStaff.position === 'Specialist') {
+          positionToFind = 'Support';
+        }
+      }
+
+      const foundPosition = availablePositions.find(position => position.name === positionToFind);
+      this.selectedPosition = foundPosition;
+    }
+  },
   methods: {
     onUserLookup,
     onSubmit,
+    editStaff,
+    addStaff,
+    onRemoveStaff,
     availablePositions,
     disableForm,
-    getHeaderText
+    getHeaderText,
+    getStaffFullName,
+    getStaffPosition,
+    getCloseButtonClass
   }
 };
 

--- a/modules/concom/sitesupport/department-staff-parser.js
+++ b/modules/concom/sitesupport/department-staff-parser.js
@@ -1,6 +1,8 @@
 const extractStaff = (staff) => {
   return {
     id: parseInt(staff.member?.id) ?? -1,
+    deptStaffId: parseInt(staff.id) ?? -1,
+    deptId: parseInt(staff.department.id) ?? -1,
     departmentName: staff.department?.name ?? '',
     divisionName: staff.department?.parent?.name,
     firstName: staff.member?.first_name ?? '',
@@ -12,7 +14,7 @@ const extractStaff = (staff) => {
   }
 };
 
-const sortAlphabetical = (staff, otherStaff) => {
+export const sortStaffByPosition = (staff, otherStaff) => {
   if (staff.position === 'Head' && otherStaff.position !== 'Head') {
     return -1;
   } else if (staff.position === 'Sub-Head' && otherStaff.position !== 'Sub-Head') {
@@ -23,6 +25,5 @@ const sortAlphabetical = (staff, otherStaff) => {
 };
 
 export const extractDepartmentStaff = (staffData) => {
-  return staffData.map((item) => extractStaff(item))
-    .sort(sortAlphabetical);
+  return staffData.map((item) => extractStaff(item));
 };

--- a/test/sitesupport/modules/staff/__tests__/__snapshots__/department-staff-parser.test.js.snap
+++ b/test/sitesupport/modules/staff/__tests__/__snapshots__/department-staff-parser.test.js.snap
@@ -4,6 +4,8 @@ exports[`Department Staff Parser parses Department Staff 1`] = `
 [
   {
     "departmentName": "Book Swap",
+    "deptId": 105,
+    "deptStaffId": 45,
     "divisionName": "Activities",
     "email": "copgoc@email.net",
     "firstName": "copgoc",
@@ -15,6 +17,8 @@ exports[`Department Staff Parser parses Department Staff 1`] = `
   },
   {
     "departmentName": "Book Swap",
+    "deptId": 105,
+    "deptStaffId": 46,
     "divisionName": "Activities",
     "email": "MifRowgac@email.net",
     "firstName": "MifRowgac",
@@ -26,6 +30,8 @@ exports[`Department Staff Parser parses Department Staff 1`] = `
   },
   {
     "departmentName": "Book Swap",
+    "deptId": 105,
+    "deptStaffId": 47,
     "divisionName": "Activities",
     "email": "baunocKum@email.net",
     "firstName": "baunocKum",
@@ -42,6 +48,8 @@ exports[`Department Staff Parser parses Division Staff 1`] = `
 [
   {
     "departmentName": "Activities",
+    "deptId": 1,
+    "deptStaffId": 1,
     "divisionName": undefined,
     "email": "test-admin@example.com",
     "firstName": "Test",
@@ -53,6 +61,8 @@ exports[`Department Staff Parser parses Division Staff 1`] = `
   },
   {
     "departmentName": "Activities",
+    "deptId": 1,
+    "deptStaffId": 2,
     "divisionName": undefined,
     "email": "pezgiwPuh@email.net",
     "firstName": "pezgiwPuh",
@@ -64,6 +74,8 @@ exports[`Department Staff Parser parses Division Staff 1`] = `
   },
   {
     "departmentName": "Activities",
+    "deptId": 1,
+    "deptStaffId": 3,
     "divisionName": undefined,
     "email": "Wirtesvai@email.net",
     "firstName": "Wirtesvai",


### PR DESCRIPTION
PR Includes:
- Provides "Edit" button in UI for users with appropriate permissions
- Populates sidebar with staff member details when "Edit" clicked
- Allows updating staff member note and position
- Allows removal of staff member from department

Made as much effort as possible to keep API requests low. Editing or removing staff members modifies the list of staff members that we have collected on page load rather than making additional requests to perform updates.

Please note that the ordering of these users does not change when modifying in place like this. I did attempt to do some sorting on the list when editing, but was not successful - additional effort may lead to results but for now I accepted this behavior once implemented.

Because the sidebar is rendered by the `staff-list.js` component, additional properties were added that have been injected for use by other components. Also because this was dragging on a bit longer than I intended, and I'd like to focus on some other areas that will help us, I chose to `watchEffect()` here for the division-level staff arrays instead of opting to use the built-in `Suspense` component that we could leverage here due to use of asynchronous calls.

I tried to keep the PR on the small side but I am seeing that it got a bit bigger than intended. I could potentially break out the behavior for API updates and the UI updates into separate PRs.

As with other PRs so far, if testing in your own UI, you will need to remove the entire contents of modules/concom/pages/body.inc and then add:

<div id="staff-app">
  <staff-list></staff-list>
</div>

In addition, you will need to uncomment the imports and components in modules/concom/sitesupport/concom_v2.js