### PR TITLE
First pass restructure RBAC

### DIFF
--- a/api/src/App/App.php
+++ b/api/src/App/App.php
@@ -57,12 +57,14 @@ require __DIR__.'/Dependencies.php';
 require __DIR__.'/Routes.php';
 require __DIR__.'/OAuth2.php';
 require __DIR__.'/Vendors.php';
+require __DIR__.'/Install.php';
 
 $settings = require __DIR__.'/Settings.php';
 $app = new \Slim\App($settings);
 $container = $app->getContainer();
 setupAPIDependencies($app, $settings);
 setupAPIVendors($settings);
+setupInstall($container);
 $oauth = setupOAUTH2();
 $server = $oauth[0];
 $storage = $oauth[1];

--- a/api/src/App/Dependencies.php
+++ b/api/src/App/Dependencies.php
@@ -5,6 +5,7 @@
 
 use Psr\Container\ContainerInterface;
 use App\Handler\ApiError;
+use App\Handler\RBAC;
 use Slim\App;
 
 /* setupAPIDependencies */
@@ -28,6 +29,10 @@ function setupAPIDependencies(App $app, array $settings)
         $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
         $pdo->setAttribute(PDO::ATTR_DEFAULT_FETCH_MODE, PDO::FETCH_ASSOC);
         return $pdo;
+    };
+
+    $container['RBAC'] = function (): RBAC {
+        return new RBAC;
     };
 
 }

--- a/api/src/App/Install.php
+++ b/api/src/App/Install.php
@@ -48,7 +48,7 @@ function setupInstall($container): void
     if (!$data || $data['Value'] != md5(json_encode($rbac))) {
      */
     foreach ($rbac as $entry) {
-        \ciab\RBAC::registerPermissions($entry);
+        $container->RBAC::registerPermissions($entry);
     }
 
     /*
@@ -56,7 +56,7 @@ function setupInstall($container): void
      * again, in the future not run every time but only when needed
      */
     foreach ($baseClasses as $class) {
-        $class::install($container->db);
+        $class::install($container);
     }
 
     global $DISABLEDMODULES;
@@ -74,9 +74,9 @@ function setupInstall($container): void
                         foreach ($module_settings['baseControllers'] as $base) {
                             $result = $base::permissions($container->db);
                             if (!empty($result)) {
-                                \ciab\RBAC::registerPermissions(array_unique(array_merge($rbac, $result)));
+                                $container->RBAC::registerPermissions(array_unique(array_merge($rbac, $result)));
                             }
-                            $base::install($container->db);
+                            $base::install($container);
                         }
                     }
                 }

--- a/api/src/App/Install.php
+++ b/api/src/App/Install.php
@@ -79,6 +79,9 @@ function setupInstall($container): void
                             $base::install($container);
                         }
                     }
+                    if (method_exists($module_settings['module'], 'install')) {
+                        call_user_func(array($module_settings['module'], 'install'), $container);
+                    }
                 }
             }
         }

--- a/api/src/App/Install.php
+++ b/api/src/App/Install.php
@@ -1,0 +1,87 @@
+<?php declare(strict_types=1);
+/*.
+    require_module 'standard';
+.*/
+
+require_once __DIR__.'/../../../modules/concom/functions/RBAC.inc';
+
+use Atlas\Query\Select;
+
+/* setupInstall */
+
+
+function setupInstall($container): void
+{
+    $baseClasses = [
+        'App\Controller\Cycle\BaseCycle',
+        'App\Controller\Event\BaseEvent',
+        'Vendor\Payment\BasePayment',
+        'App\Controller\Announcement\BaseAnnouncement',
+        'App\Controller\Deadline\BaseDeadline',
+        'App\Controller\Department\BaseDepartment',
+        'App\Controller\Member\BaseMember',
+        'App\Controller\Permissions\GetMemberPermissions',
+        'App\Controller\Permissions\BasePermission',
+        'App\Controller\Stores\BaseStore',
+        'App\Controller\Stores\BaseProduct',
+        'App\Controller\System\BaseSystem',
+    ];
+
+    $rbac = [
+    ];
+
+    foreach ($baseClasses as $class) {
+        $result = $class::permissions($container->db);
+        if (!empty($result)) {
+            $rbac = array_unique(array_merge($rbac, $result));
+        }
+    }
+
+    /*
+     * A future data check so that with other platforms this will not need to be run on every execution
+     *
+    $data = Select::new($container->db)
+        ->columns('Value')
+        ->from('Configuration')
+        ->whereEquals(['Field' => 'APIMD5'])
+        ->fetchOne();
+    if (!$data || $data['Value'] != md5(json_encode($rbac))) {
+     */
+    foreach ($rbac as $entry) {
+        \ciab\RBAC::registerPermissions($entry);
+    }
+
+    /*
+     * custom install/update work can be done here also,
+     * again, in the future not run every time but only when needed
+     */
+    foreach ($baseClasses as $class) {
+        $class::install($container->db);
+    }
+
+    global $DISABLEDMODULES;
+
+    $modules = scandir(__DIR__.'/../Modules');
+    foreach ($modules as $key => $value) {
+        if (!in_array($value, array(',', '..'))) {
+            if (in_array($value, $DISABLEDMODULES)) {
+                continue;
+            }
+            if (is_dir(__DIR__.'/../Modules/'.$value)) {
+                if (is_file(__DIR__.'/../Modules/'.$value.'/Settings.php')) {
+                    $module_settings = include(__DIR__.'/../Modules/'.$value.'/Settings.php');
+                    if (array_key_exists('baseControllers', $module_settings)) {
+                        foreach ($module_settings['baseControllers'] as $base) {
+                            $result = $base::permissions($container->db);
+                            if (!empty($result)) {
+                                \ciab\RBAC::registerPermissions(array_unique(array_merge($rbac, $result)));
+                            }
+                            $base::install($container->db);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+}

--- a/api/src/Controller/Announcement/BaseAnnouncement.php
+++ b/api/src/Controller/Announcement/BaseAnnouncement.php
@@ -122,7 +122,6 @@ abstract class BaseAnnouncement extends BaseController
     public function __construct(Container $container)
     {
         parent::__construct('announcement', $container);
-        \ciab\RBAC::customizeRBAC('\App\Controller\Announcement\BaseAnnouncement::customizeAnnouncementRBAC');
 
         $this->includes = [
         new IncludeResource(
@@ -136,6 +135,45 @@ abstract class BaseAnnouncement extends BaseController
             'department'
         )
         ];
+
+    }
+
+
+    public static function install($database): void
+    {
+        \ciab\RBAC::customizeRBAC('\App\Controller\Announcement\BaseAnnouncement::customizeAnnouncementRBAC');
+
+    }
+
+
+    public static function permissions($database): array
+    {
+        $result = ['api.get.announcement.staff', 'api.get.announcement.all',
+            'api.post.announcement.all', 'api.delete.announcement.all',
+            'api.put.announcement.all' ];
+        $positions = [];
+        $values = Select::new($database)
+            ->columns('PositionID', 'Name')
+            ->from('ConComPositions')
+            ->orderBy('`PositionID` ASC')
+            ->fetchAll();
+        foreach ($values as $value) {
+            $positions[intval($value['PositionID'])] = $value['Name'];
+        }
+
+        $values = Select::new($database)
+            ->columns('DepartmentID')
+            ->from('Departments')
+            ->fetchAll();
+        foreach ($values as $value) {
+            $perm_get = 'api.get.announcement.'.$value['DepartmentID'];
+            $perm_del = 'api.delete.announcement.'.$value['DepartmentID'];
+            $perm_pos = 'api.post.announcement.'.$value['DepartmentID'];
+            $perm_put = 'api.put.announcement.'.$value['DepartmentID'];
+            $result = array_merge($result, [$perm_get, $perm_del, $perm_pos, $perm_put]);
+        }
+
+        return $result;
 
     }
 

--- a/api/src/Controller/Announcement/BaseAnnouncement.php
+++ b/api/src/Controller/Announcement/BaseAnnouncement.php
@@ -139,9 +139,9 @@ abstract class BaseAnnouncement extends BaseController
     }
 
 
-    public static function install($database): void
+    public static function install($container): void
     {
-        \ciab\RBAC::customizeRBAC('\App\Controller\Announcement\BaseAnnouncement::customizeAnnouncementRBAC');
+        $container->RBAC::customizeRBAC('\App\Controller\Announcement\BaseAnnouncement::customizeAnnouncementRBAC');
 
     }
 

--- a/api/src/Controller/Announcement/BaseAnnouncement.php
+++ b/api/src/Controller/Announcement/BaseAnnouncement.php
@@ -193,7 +193,7 @@ abstract class BaseAnnouncement extends BaseController
     }
 
 
-    public static function customizeAnnouncementRBAC($instance, $database)
+    public static function customizeAnnouncementRBAC($rbac, $database)
     {
         $positions = [];
         $values = Select::new($database)
@@ -217,20 +217,17 @@ abstract class BaseAnnouncement extends BaseController
             $target_h = $value['DepartmentID'].'.'.array_keys($positions)[0];
             $target_r = $value['DepartmentID'].'.'.end(array_keys($positions));
             try {
-                $role = $instance->getRole($target_h);
-                $role->addPermission($perm_del);
-                $role->addPermission($perm_pos);
-                $role->addPermission($perm_put);
-                $role = $instance->getRole($target_r);
-                $role->addPermission($perm_get);
+                $rbac->grantPermission($target_h, $perm_del);
+                $rbac->grantPermission($target_h, $perm_pos);
+                $rbac->grantPermission($target_h, $perm_put);
+                $rbac->grantPermission($target_r, $perm_get);
             } catch (Exception\InvalidArgumentException $e) {
                 error_log($e);
             }
         }
 
         try {
-            $role = $instance->getRole('all.staff');
-            $role->addPermission('api.get.announcement.staff');
+            $rbac->grantPermission('all.staff', 'api.get.announcement.staff');
         } catch (Exception\InvalidArgumentException $e) {
             error_log($e);
         }

--- a/api/src/Controller/BaseController.php
+++ b/api/src/Controller/BaseController.php
@@ -117,9 +117,6 @@ use Slim\Http\Request;
 use Slim\Http\Environment;
 use Atlas\Query\Select;
 
-require_once __DIR__.'/../../../backends/RBAC.inc';
-require_once __DIR__.'/../../../modules/concom/functions/RBAC.inc';
-
 class NotFoundException extends Exception
 {
 
@@ -577,7 +574,7 @@ abstract class BaseController
     ) {
         $valid = false;
         foreach ($permissions as $perm) {
-            if (!$valid && \ciab\RBAC::havePermission($perm)) {
+            if (!$valid && $this->container->RBAC::havePermission($perm)) {
                 $valid = true;
             }
         }
@@ -764,7 +761,14 @@ abstract class BaseController
     }
 
 
-    abstract public static function install($database): void;
+    public function getContainer(): Container
+    {
+        return $this->container;
+
+    }
+
+
+    abstract public static function install($container): void;
 
 
     abstract public static function permissions($database): ?array;

--- a/api/src/Controller/BaseController.php
+++ b/api/src/Controller/BaseController.php
@@ -764,5 +764,11 @@ abstract class BaseController
     }
 
 
+    abstract public static function install($database): void;
+
+
+    abstract public static function permissions($database): ?array;
+
+
     /* END BaseController */
 }

--- a/api/src/Controller/BaseVendorController.php
+++ b/api/src/Controller/BaseVendorController.php
@@ -47,6 +47,36 @@ abstract class BaseVendorController extends BaseController
     }
 
 
+    abstract public static function baseInstall($databas): void;
+
+
+    abstract public static function basePermissions($database): ?array;
+
+
+    public static function install($database): void
+    {
+        if (self::$instance !== null &&
+            method_exists(self::$instance, __FUNCTION__)) {
+            self::$instance->{__FUNCTION__}($database);
+        } else {
+            self::baseInstall($database);
+        }
+
+    }
+
+
+    public static function permissions($database): ?array
+    {
+        if (self::$instance !== null &&
+            method_exists(self::$instance, __FUNCTION__)) {
+            return self::$instance->{__FUNCTION__}($database);
+        } else {
+            return self::basePermissions($database);
+        }
+
+    }
+
+
     public function __invoke(Request $request, Response $response, $args)
     {
         if (self::$instance !== null &&

--- a/api/src/Controller/BaseVendorController.php
+++ b/api/src/Controller/BaseVendorController.php
@@ -47,19 +47,19 @@ abstract class BaseVendorController extends BaseController
     }
 
 
-    abstract public static function baseInstall($databas): void;
+    abstract public static function baseInstall($container): void;
 
 
     abstract public static function basePermissions($database): ?array;
 
 
-    public static function install($database): void
+    public static function install($container): void
     {
         if (self::$instance !== null &&
             method_exists(self::$instance, __FUNCTION__)) {
-            self::$instance->{__FUNCTION__}($database);
+            self::$instance->{__FUNCTION__}($container);
         } else {
-            self::baseInstall($database);
+            self::baseInstall($container);
         }
 
     }

--- a/api/src/Controller/Cycle/BaseCycle.php
+++ b/api/src/Controller/Cycle/BaseCycle.php
@@ -93,7 +93,7 @@ abstract class BaseCycle extends BaseController
     }
 
 
-    public static function install($database): void
+    public static function install($container): void
     {
 
     }

--- a/api/src/Controller/Cycle/BaseCycle.php
+++ b/api/src/Controller/Cycle/BaseCycle.php
@@ -93,6 +93,19 @@ abstract class BaseCycle extends BaseController
     }
 
 
+    public static function install($database): void
+    {
+
+    }
+
+
+    public static function permissions($database): ?array
+    {
+        return ([ 'api.delete.cycle', 'api.post.cycle', 'api.put.cycle' ]);
+
+    }
+
+
     protected function getCycle(Request $request, Response $response, $params)
     {
         $cycle = new GetCycle($this->container);

--- a/api/src/Controller/Deadline/BaseDeadline.php
+++ b/api/src/Controller/Deadline/BaseDeadline.php
@@ -162,7 +162,7 @@ abstract class BaseDeadline extends BaseController
     }
 
 
-    public static function customizeDeadlineRBAC($instance, $database)
+    public static function customizeDeadlineRBAC($rbac, $database)
     {
         $positions = [];
         $values = Select::new($database)
@@ -186,20 +186,17 @@ abstract class BaseDeadline extends BaseController
             $target_h = $value['DepartmentID'].'.'.array_keys($positions)[0];
             $target_r = $value['DepartmentID'].'.'.end(array_keys($positions));
             try {
-                $role = $instance->getRole($target_h);
-                $role->addPermission($perm_del);
-                $role->addPermission($perm_pos);
-                $role->addPermission($perm_put);
-                $role = $instance->getRole($target_r);
-                $role->addPermission($perm_get);
+                $rbac->grantPermission($target_h, $perm_del);
+                $rbac->grantPermission($target_h, $perm_pos);
+                $rbac->grantPermission($target_h, $perm_put);
+                $rbac->grantPermission($target_r, $perm_get);
             } catch (Exception\InvalidArgumentException $e) {
                 error_log($e);
             }
         }
 
         try {
-            $role = $instance->getRole('all.staff');
-            $role->addPermission('api.get.deadline.staff');
+            $rbac->grantPermission('all.staff', 'api.get.deadline.staff');
         } catch (Exception\InvalidArgumentException $e) {
             error_log($e);
         }

--- a/api/src/Controller/Deadline/BaseDeadline.php
+++ b/api/src/Controller/Deadline/BaseDeadline.php
@@ -121,7 +121,43 @@ abstract class BaseDeadline extends BaseController
     public function __construct(Container $container)
     {
         parent::__construct('deadline', $container);
+
+    }
+
+
+    public static function install($database): void
+    {
         \ciab\RBAC::customizeRBAC('\App\Controller\Deadline\BaseDeadline::customizeDeadlineRBAC');
+
+    }
+
+
+    public static function permissions($database): ?array
+    {
+        $permissions = ['api.get.deadline.all', 'api.get.deadline.staff', 'api.post.deadline.all',
+                        'api.put.deadline.all', 'api.delete.deadline.all'];
+        $positions = [];
+        $values = Select::new($database)
+            ->columns('PositionID', 'Name')
+            ->from('ConComPositions')
+            ->orderBy('`PositionID` ASC')
+            ->fetchAll();
+        foreach ($values as $value) {
+            $positions[intval($value['PositionID'])] = $value['Name'];
+        }
+
+        $values = Select::new($database)
+            ->columns('DepartmentID')
+            ->from('Departments')
+            ->fetchAll();
+        foreach ($values as $value) {
+            $perm_get = 'api.get.deadline.'.$value['DepartmentID'];
+            $perm_del = 'api.delete.deadline.'.$value['DepartmentID'];
+            $perm_pos = 'api.post.deadline.'.$value['DepartmentID'];
+            $perm_put = 'api.put.deadline.'.$value['DepartmentID'];
+            $permissions = array_merge($permissions, [$perm_get, $perm_del, $perm_pos, $perm_put]);
+        }
+        return ($permissions);
 
     }
 

--- a/api/src/Controller/Deadline/BaseDeadline.php
+++ b/api/src/Controller/Deadline/BaseDeadline.php
@@ -125,9 +125,9 @@ abstract class BaseDeadline extends BaseController
     }
 
 
-    public static function install($database): void
+    public static function install($container): void
     {
-        \ciab\RBAC::customizeRBAC('\App\Controller\Deadline\BaseDeadline::customizeDeadlineRBAC');
+        $container->RBAC::customizeRBAC('\App\Controller\Deadline\BaseDeadline::customizeDeadlineRBAC');
 
     }
 

--- a/api/src/Controller/Department/BaseDepartment.php
+++ b/api/src/Controller/Department/BaseDepartment.php
@@ -120,6 +120,19 @@ abstract class BaseDepartment extends BaseController
     }
 
 
+    public static function install($database): void
+    {
+
+    }
+
+
+    public static function permissions($database): ?array
+    {
+        return null;
+
+    }
+
+
     public function getDepartment($id, $setself = true)
     {
         $output = parent::getDepartment($id);

--- a/api/src/Controller/Department/BaseDepartment.php
+++ b/api/src/Controller/Department/BaseDepartment.php
@@ -120,7 +120,7 @@ abstract class BaseDepartment extends BaseController
     }
 
 
-    public static function install($database): void
+    public static function install($container): void
     {
 
     }

--- a/api/src/Controller/Event/BaseEvent.php
+++ b/api/src/Controller/Event/BaseEvent.php
@@ -118,6 +118,19 @@ abstract class BaseEvent extends BaseController
     }
 
 
+    public static function install($database): void
+    {
+
+    }
+
+
+    public static function permissions($database): ?array
+    {
+        return (['api.delete.event', 'api.post.event', 'api.put.event']);
+
+    }
+
+
     private function handleDate($request, $response, $params, &$body, $dateName)
     {
         if (array_key_exists($dateName, $body)) {

--- a/api/src/Controller/Event/BaseEvent.php
+++ b/api/src/Controller/Event/BaseEvent.php
@@ -118,7 +118,7 @@ abstract class BaseEvent extends BaseController
     }
 
 
-    public static function install($database): void
+    public static function install($container): void
     {
 
     }

--- a/api/src/Controller/Member/BaseMember.php
+++ b/api/src/Controller/Member/BaseMember.php
@@ -276,7 +276,7 @@ abstract class BaseMember extends BaseController
     }
 
 
-    public static function install($database): void
+    public static function install($container): void
     {
 
     }

--- a/api/src/Controller/Member/BaseMember.php
+++ b/api/src/Controller/Member/BaseMember.php
@@ -276,5 +276,18 @@ abstract class BaseMember extends BaseController
     }
 
 
+    public static function install($database): void
+    {
+
+    }
+
+
+    public static function permissions($database): ?array
+    {
+        return ['api.get.member', 'admin.sudo', 'api.put.member', 'api.put.member.password'];
+
+    }
+
+
     /* End BaseMember */
 }

--- a/api/src/Controller/Member/FindMembers.php
+++ b/api/src/Controller/Member/FindMembers.php
@@ -106,7 +106,7 @@ class FindMembers extends BaseMember
             ->from('`Members` m1')
             ->orderBy('AccountID ASC');
 
-        if (!$this->internal && !\ciab\RBAC::havePermission('api.get.member')) {
+        if (!$this->internal && !$this->container->RBAC::havePermission('api.get.member')) {
             $id = $request->getAttribute('oauth2-token')['user_id'];
             $select->andWhere('AccountID = ', $id);
         }

--- a/api/src/Controller/Member/GetConfiguration.php
+++ b/api/src/Controller/Member/GetConfiguration.php
@@ -122,7 +122,7 @@ class GetConfiguration extends BaseMember
         } else {
             $id = $user;
         }
-        if ($user != $id && !\ciab\RBAC::havePermission("api.get.configuration")) {
+        if ($user != $id && !$this->container->RBAC::havePermission("api.get.configuration")) {
             throw new PermissionDeniedException();
         }
 

--- a/api/src/Controller/Member/PutConfiguration.php
+++ b/api/src/Controller/Member/PutConfiguration.php
@@ -85,7 +85,7 @@ class PutConfiguration extends BaseMember
         }
 
         if ($accountID != $user &&
-            !\ciab\RBAC::havePermission("api.put.member")) {
+            !$this->container->RBAC::havePermission("api.put.member")) {
             throw new PermissionDeniedException();
         }
 

--- a/api/src/Controller/Member/PutMember.php
+++ b/api/src/Controller/Member/PutMember.php
@@ -105,7 +105,7 @@ class PutMember extends BaseMember
         if (!$this->privilaged) {
             $user = $request->getAttribute('oauth2-token')['user_id'];
             if ($accountID != $user &&
-                !\ciab\RBAC::havePermission("api.put.member")) {
+                !$this->container->RBAC::havePermission("api.put.member")) {
                 throw new PermissionDeniedException();
             }
         }

--- a/api/src/Controller/Member/PutPassword.php
+++ b/api/src/Controller/Member/PutPassword.php
@@ -185,7 +185,7 @@ class PutPassword extends BaseMember
         }
 
         if (!$this->privilaged) {
-            if (!\ciab\RBAC::havePermission("api.put.member.password")) {
+            if (!$this->container->RBAC::havePermission("api.put.member.password")) {
                 $attribute = $request->getAttribute('oauth2-token');
                 if ($attribute) {
                     $user = $attribute['user_id'];

--- a/api/src/Controller/Payment/BasePayment.php
+++ b/api/src/Controller/Payment/BasePayment.php
@@ -43,5 +43,18 @@ abstract class BasePayment extends BaseVendorController
     }
 
 
+    public static function baseInstall($database): void
+    {
+
+    }
+
+
+    public static function basePermissions($database): ?array
+    {
+        return null;
+
+    }
+
+
     /* End BasePayment */
 }

--- a/api/src/Controller/Permissions/AnnouncementPermission.php
+++ b/api/src/Controller/Permissions/AnnouncementPermission.php
@@ -16,7 +16,6 @@ abstract class AnnouncementPermission extends BasePermission
     public function __construct(Container $container)
     {
         parent::__construct($container, 'announcement', ['put', 'post', 'delete']);
-        \ciab\RBAC::customizeRBAC('\App\Controller\Announcement\BaseAnnouncement\customizeAnnouncementRBAC');
 
     }
 

--- a/api/src/Controller/Permissions/BasePermission.php
+++ b/api/src/Controller/Permissions/BasePermission.php
@@ -540,7 +540,7 @@ abstract class BasePermission extends BaseController
         $entry = [
         'type' => 'permission_entry',
         'subtype' => $subtype.'_'.$method,
-        'allowed' => $allowed,
+        'allowed' => ($allowed) ? 1 : 0,
         'action' => $link
         ];
         $entry['subdata'] = [
@@ -568,7 +568,7 @@ abstract class BasePermission extends BaseController
         if (array_key_exists('department', $params)) {
             $data = $this->getDepartment($params['department']);
             $allowed = ($this->container->RBAC::havePermission("api.$methodArg.{$this->restype}.${data['id']}") ||
-                        $this->container->RBAC::havePermission("api.$methodArg.{$this->restype}.all"));
+                        $this->container->RBAC::havePermission("api.$methodArg.{$this->restype}.all")) ? 1 : 0;
             ;
             $result = $this->buildDeptEntry(
                 $data['id'],
@@ -594,7 +594,7 @@ abstract class BasePermission extends BaseController
             foreach ($methods as $method) {
                 foreach ($Departments as $key => $data) {
                     $allowed = ($this->container->RBAC::havePermission("api.$method.{$this->restype}.${data['id']}") ||
-                                $this->container->RBAC::havePermission("api.$method.{$this->restype}.all"));
+                                $this->container->RBAC::havePermission("api.$method.{$this->restype}.all")) ? 1 : 0;
                     ;
                     if ($allowed) {
                         $result = $this->buildDeptEntry(
@@ -625,7 +625,7 @@ abstract class BasePermission extends BaseController
     {
         $path = $request->getUri()->getBaseUrl();
         $allowed = ($this->container->RBAC::havePermission("api.$method.$restype.$id") ||
-                    $this->container->RBAC::havePermission("api.$method.$restype.all"));
+                    $this->container->RBAC::havePermission("api.$method.$restype.all")) ? 1 : 0;
         ;
         return $this->buildDeptEntry(
             $id,

--- a/api/src/Controller/Permissions/BasePermission.php
+++ b/api/src/Controller/Permissions/BasePermission.php
@@ -520,6 +520,21 @@ abstract class BasePermission extends BaseController
     }
 
 
+    public static function install($database): void
+    {
+        \ciab\RBAC::customizeRBAC('\App\Controller\Announcement\BaseAnnouncement\customizeAnnouncementRBAC');
+        \ciab\RBAC::customizeRBAC('\App\Controller\Deadline\BaseDeadline::customizeDeadlineRBAC');
+
+    }
+
+
+    public static function permissions($database): ?array
+    {
+        return null;
+
+    }
+
+
     protected function buildDeptEntry($id, $allowed, $subtype, $method, $link) : array
     {
         $entry = [

--- a/api/src/Controller/Permissions/BasePermission.php
+++ b/api/src/Controller/Permissions/BasePermission.php
@@ -520,10 +520,10 @@ abstract class BasePermission extends BaseController
     }
 
 
-    public static function install($database): void
+    public static function install($container): void
     {
-        \ciab\RBAC::customizeRBAC('\App\Controller\Announcement\BaseAnnouncement\customizeAnnouncementRBAC');
-        \ciab\RBAC::customizeRBAC('\App\Controller\Deadline\BaseDeadline::customizeDeadlineRBAC');
+        $container->RBAC::customizeRBAC('\App\Controller\Announcement\BaseAnnouncement\customizeAnnouncementRBAC');
+        $container->RBAC::customizeRBAC('\App\Controller\Deadline\BaseDeadline::customizeDeadlineRBAC');
 
     }
 
@@ -567,8 +567,8 @@ abstract class BasePermission extends BaseController
         $path = $request->getUri()->getBaseUrl();
         if (array_key_exists('department', $params)) {
             $data = $this->getDepartment($params['department']);
-            $allowed = (\ciab\RBAC::havePermission("api.$methodArg.{$this->restype}.${data['id']}") ||
-                        \ciab\RBAC::havePermission("api.$methodArg.{$this->restype}.all"));
+            $allowed = ($this->container->RBAC::havePermission("api.$methodArg.{$this->restype}.${data['id']}") ||
+                        $this->container->RBAC::havePermission("api.$methodArg.{$this->restype}.all"));
             ;
             $result = $this->buildDeptEntry(
                 $data['id'],
@@ -593,8 +593,8 @@ abstract class BasePermission extends BaseController
             }
             foreach ($methods as $method) {
                 foreach ($Departments as $key => $data) {
-                    $allowed = (\ciab\RBAC::havePermission("api.$method.{$this->restype}.${data['id']}") ||
-                                \ciab\RBAC::havePermission("api.$method.{$this->restype}.all"));
+                    $allowed = ($this->container->RBAC::havePermission("api.$method.{$this->restype}.${data['id']}") ||
+                                $this->container->RBAC::havePermission("api.$method.{$this->restype}.all"));
                     ;
                     if ($allowed) {
                         $result = $this->buildDeptEntry(
@@ -624,8 +624,8 @@ abstract class BasePermission extends BaseController
     protected function buildEntry($request, $id, $method, $restype): array
     {
         $path = $request->getUri()->getBaseUrl();
-        $allowed = (\ciab\RBAC::havePermission("api.$method.$restype.$id") ||
-                    \ciab\RBAC::havePermission("api.$method.$restype.all"));
+        $allowed = ($this->container->RBAC::havePermission("api.$method.$restype.$id") ||
+                    $this->container->RBAC::havePermission("api.$method.$restype.all"));
         ;
         return $this->buildDeptEntry(
             $id,

--- a/api/src/Controller/Permissions/DeadlinePermission.php
+++ b/api/src/Controller/Permissions/DeadlinePermission.php
@@ -17,7 +17,6 @@ abstract class DeadlinePermission extends BasePermission
     public function __construct(Container $container)
     {
         parent::__construct($container, 'deadline', ['get', 'put', 'post', 'delete']);
-        \ciab\RBAC::customizeRBAC('\App\Controller\Deadline\BaseDeadline::customizeDeadlineRBAC');
 
     }
 

--- a/api/src/Controller/Permissions/GenericResource.php
+++ b/api/src/Controller/Permissions/GenericResource.php
@@ -16,7 +16,7 @@ class GenericResource extends GenericPermission
     {
         $path = $request->getUri()->getBaseUrl();
         $permission = 'api.'.$method.'.'.$resourceName;
-        $allowed = ($this->container->RBAC::havePermission($permission));
+        $allowed = ($this->container->RBAC::havePermission($permission)) ? 1 : 0;
 
         $entry = [
         'type' => 'permission_entry',

--- a/api/src/Controller/Permissions/GenericResource.php
+++ b/api/src/Controller/Permissions/GenericResource.php
@@ -16,7 +16,7 @@ class GenericResource extends GenericPermission
     {
         $path = $request->getUri()->getBaseUrl();
         $permission = 'api.'.$method.'.'.$resourceName;
-        $allowed = (\ciab\RBAC::havePermission($permission));
+        $allowed = ($this->container->RBAC::havePermission($permission));
 
         $entry = [
         'type' => 'permission_entry',

--- a/api/src/Controller/Permissions/GetMemberPermissions.php
+++ b/api/src/Controller/Permissions/GetMemberPermissions.php
@@ -81,7 +81,7 @@ class GetMemberPermissions extends BaseController
             $result[] = [
                 'type' => 'permission_entry',
                 'subtype' => $entry,
-                'allowed' => true,
+                'allowed' => 1,
                 ];
         }
 

--- a/api/src/Controller/Permissions/GetMemberPermissions.php
+++ b/api/src/Controller/Permissions/GetMemberPermissions.php
@@ -52,7 +52,7 @@ class GetMemberPermissions extends BaseController
     }
 
 
-    public static function install($database): void
+    public static function install($container): void
     {
 
     }
@@ -75,7 +75,7 @@ class GetMemberPermissions extends BaseController
             $id = $request->getAttribute('oauth2-token')['user_id'];
         }
 
-        $data = \ciab\RBAC::getMemberPermissions($id);
+        $data = $this->container->RBAC::getMemberPermissions($id);
         $result = array();
         foreach ($data as $entry) {
             $result[] = [

--- a/api/src/Controller/Permissions/GetMemberPermissions.php
+++ b/api/src/Controller/Permissions/GetMemberPermissions.php
@@ -52,6 +52,19 @@ class GetMemberPermissions extends BaseController
     }
 
 
+    public static function install($database): void
+    {
+
+    }
+
+
+    public static function permissions($database): ?array
+    {
+        return null;
+
+    }
+
+
     public function buildResource(Request $request, Response $response, $params): array
     {
         $id = null;

--- a/api/src/Controller/Stores/BaseProduct.php
+++ b/api/src/Controller/Stores/BaseProduct.php
@@ -27,7 +27,7 @@ abstract class BaseProduct extends BaseController
     }
 
 
-    public static function install($database): void
+    public static function install($container): void
     {
 
     }

--- a/api/src/Controller/Stores/BaseProduct.php
+++ b/api/src/Controller/Stores/BaseProduct.php
@@ -27,6 +27,19 @@ abstract class BaseProduct extends BaseController
     }
 
 
+    public static function install($database): void
+    {
+
+    }
+
+
+    public static function permissions($database): ?array
+    {
+        return null;
+
+    }
+
+
     protected function getProduct(array $params, Request $request, Response $response, &$error)
     {
         $select = Select::new($this->container->db);

--- a/api/src/Controller/Stores/BaseStore.php
+++ b/api/src/Controller/Stores/BaseStore.php
@@ -99,7 +99,7 @@ abstract class BaseStore extends BaseController
     }
 
 
-    public static function install($database): void
+    public static function install($container): void
     {
 
     }

--- a/api/src/Controller/Stores/BaseStore.php
+++ b/api/src/Controller/Stores/BaseStore.php
@@ -99,6 +99,19 @@ abstract class BaseStore extends BaseController
     }
 
 
+    public static function install($database): void
+    {
+
+    }
+
+
+    public static function permissions($database): ?array
+    {
+        return null;
+
+    }
+
+
     protected function getStore(array $params, Request $request, Response $response, &$error)
     {
         $select = Select::new($this->container->db);

--- a/api/src/Controller/System/BaseSystem.php
+++ b/api/src/Controller/System/BaseSystem.php
@@ -26,5 +26,18 @@ abstract class BaseSystem extends BaseController
     }
 
 
+    public static function install($database): void
+    {
+
+    }
+
+
+    public static function permissions($database): ?array
+    {
+        return ['api.get.log', 'api.get.configuration', 'api.put.log', 'api.put.configuration'];
+
+    }
+
+
     /* End BaseSystem */
 }

--- a/api/src/Controller/System/BaseSystem.php
+++ b/api/src/Controller/System/BaseSystem.php
@@ -26,7 +26,7 @@ abstract class BaseSystem extends BaseController
     }
 
 
-    public static function install($database): void
+    public static function install($container): void
     {
 
     }

--- a/api/src/Controller/TraitScope.php
+++ b/api/src/Controller/TraitScope.php
@@ -12,14 +12,14 @@ trait TraitScope
                 $data[$index]['scope'] = 2;
             }
         }
-        if (!\ciab\RBAC::havePermission("api.get.{$this->api_type}.all")) {
+        if (!$this->container->RBAC::havePermission("api.get.{$this->api_type}.all")) {
             foreach ($data as $index => $target) {
                 if ($target['scope'] >= 2) {
-                    if (!\ciab\RBAC::havePermission("api.get.{$this->api_type}.{$target['department']}")) {
+                    if (!$this->container->RBAC::havePermission("api.get.{$this->api_type}.{$target['department']}")) {
                         unset($data[$index]);
                     }
                 } elseif ($target['scope'] == 1) {
-                    if (!\ciab\RBAC::havePermission("api.get.{$this->api_type}.staff")) {
+                    if (!$this->container->RBAC::havePermission("api.get.{$this->api_type}.staff")) {
                         unset($data[$index]);
                     }
                 }

--- a/api/src/Handler/RBAC.php
+++ b/api/src/Handler/RBAC.php
@@ -113,5 +113,59 @@ class RBAC
     }
 
 
+    public static function addRole(/*.string.*/$role, /*.array.*/$parents = null)
+    {
+        if (self::instance() !== null) {
+            return self::instance()->addRole($role, $parents);
+        }
+
+    }
+
+
+    public static function removeRole(/*.string.*/$role)
+    {
+        if (self::instance() !== null) {
+            return self::instance()->removeRole($role);
+        }
+
+    }
+
+
+    public static function addRoleParents(/*.string.*/$role, /*.array.*/$parents)
+    {
+        if (self::instance() !== null) {
+            return self::instance()->addRoleParents($role, $parents);
+        }
+
+    }
+
+
+    public static function removeRoleParent(/*.string.*/$role, /*.string.*/$parent)
+    {
+        if (self::instance() !== null) {
+            return self::instance()->removeRoleParent($role, $parent);
+        }
+
+    }
+
+
+    public static function grantPermission(/*.string.*/$role, /*.string.*/$permission)
+    {
+        if (self::instance() !== null) {
+            return self::instance()->grantPermission($role, $permission);
+        }
+
+    }
+
+
+    public static function revokePermission(/*.string.*/$role, /*.string.*/$permission)
+    {
+        if (self::instance() !== null) {
+            return self::instance()->revokePermission($role, $permission);
+        }
+
+    }
+
+
     /* end class */
 }

--- a/api/src/Handler/RBAC.php
+++ b/api/src/Handler/RBAC.php
@@ -1,0 +1,117 @@
+<?php
+
+/*.
+    require_module 'standard';
+.*/
+
+namespace App\Handler;
+
+#require_once __DIR__.'/../../../modules/concom/functions/RBAC.inc';
+
+class RBAC
+{
+
+    protected static $instance = null;
+
+    protected static $custom = array();
+
+
+    public function __construct()
+    {
+
+    }
+
+
+    public function __clone()
+    {
+
+    }
+
+
+    public static function instance()
+    {
+        if (self::$instance === null) {
+            if (class_exists('\\concom\\ConComRBAC')) {
+                self::$instance = \concom\ConComRBAC::instance();
+            }
+        }
+
+        return self::$instance;
+
+    }
+
+
+    public static function reload()
+    {
+        if (self::$instance !== null) {
+            self::$instance = null;
+            if (!empty(self::$custom)) {
+                if (self::instance() !== null) {
+                    foreach (self::$custom as $entry) {
+                        return self::instance()->customizeRBAC($entry);
+                    }
+                }
+            }
+        }
+
+    }
+
+
+    public static function havePermission(/*.string.*/ $name)
+    {
+        if (self::instance() !== null) {
+            return self::instance()->havePermission($name);
+        } else {
+            return (array_key_exists('IS_ADMIN', $_SESSION) &&
+                    $_SESSION['IS_ADMIN']);
+        }
+
+    }
+
+
+    public static function getPermissions(
+        /*.string.*/ $role,
+        /*.bool.*/ $children = true
+    ) {
+        if (self::instance() !== null) {
+            return self::instance()->getPermissions($role, $children);
+        } else {
+            return null;
+        }
+
+    }
+
+
+    public static function getMemberPermissions(
+        /*.int.*/ $id
+    ) {
+        if (self::instance() !== null) {
+            return self::instance()->getMemberPermissions($id);
+        } else {
+            return null;
+        }
+
+    }
+
+
+    public static function customizeRBAC($entry)
+    {
+        if (self::instance() !== null) {
+            self::$custom[] = $entry;
+            return self::instance()->customizeRBAC($entry);
+        }
+
+    }
+
+
+    public static function registerPermissions(/*.mixed.*/$permissions)
+    {
+        if (self::instance() !== null) {
+            return self::instance()->registerPermissions($permissions);
+        }
+
+    }
+
+
+    /* end class */
+}

--- a/api/src/Modules/BaseModule.php
+++ b/api/src/Modules/BaseModule.php
@@ -21,5 +21,14 @@ abstract class BaseModule
     }
 
 
+    /**
+     * Optional member
+     *
+     * The static 'install' member will be called first initialization of the system
+     *
+     * static public function install($container);
+     */
+
+
     /* End BaseModule */
 }

--- a/api/src/Modules/registration/Controller/BaseRegistration.php
+++ b/api/src/Modules/registration/Controller/BaseRegistration.php
@@ -21,6 +21,25 @@ abstract class BaseRegistration extends BaseController
     }
 
 
+    public static function install($database): void
+    {
+
+    }
+
+
+    public static function permissions($database): ?array
+    {
+        return(['api.set.registration.configuration',
+            'api.registration.ticket.checkin', 'api.registration.ticket.delete',
+            'api.registration.ticket.email', 'api.registration.ticket.get',
+            'api.registration.ticket.list', 'api.registration.ticket.lost',
+            'api.registration.ticket.pickup', 'api.registration.ticket.post',
+            'api.registration.ticket.print', 'api.registration.ticket.put',
+            'api.registration.ticket.unvoid', 'api.registration.ticket.void' ]);
+
+    }
+
+
     protected function checkPutPermission()
     {
         $permissions = ['api.set.registration.configuration'];

--- a/api/src/Modules/registration/Controller/BaseRegistration.php
+++ b/api/src/Modules/registration/Controller/BaseRegistration.php
@@ -21,7 +21,7 @@ abstract class BaseRegistration extends BaseController
     }
 
 
-    public static function install($database): void
+    public static function install($container): void
     {
 
     }

--- a/api/src/Modules/registration/Controller/Ticket/BaseTicket.php
+++ b/api/src/Modules/registration/Controller/Ticket/BaseTicket.php
@@ -361,9 +361,8 @@ abstract class BaseTicket extends BaseRegistration
         }
         $aid = $data['AccountID'];
 
-        if ($user != $aid && $permission &&
-            !$this->container->RBAC::havePermission($permission)) {
-            throw new PermissionDeniedException();
+        if ($user != $aid && $permission) {
+            $this->checkPermissions([$permission]);
         }
 
         return $aid;

--- a/api/src/Modules/registration/Controller/Ticket/BaseTicket.php
+++ b/api/src/Modules/registration/Controller/Ticket/BaseTicket.php
@@ -362,7 +362,7 @@ abstract class BaseTicket extends BaseRegistration
         $aid = $data['AccountID'];
 
         if ($user != $aid && $permission &&
-            !\ciab\RBAC::havePermission($permission)) {
+            !$this->container->RBAC::havePermission($permission)) {
             throw new PermissionDeniedException();
         }
 

--- a/api/src/Modules/registration/Controller/Ticket/ListTickets.php
+++ b/api/src/Modules/registration/Controller/Ticket/ListTickets.php
@@ -207,7 +207,7 @@ class ListTickets extends BaseTicketInclude
         }
 
         if ($user != $aid &&
-            !\ciab\RBAC::havePermission('api.registration.ticket.list')) {
+            !$this->container->RBAC::havePermission('api.registration.ticket.list')) {
             throw new PermissionDeniedException();
         }
 

--- a/api/src/Modules/registration/Controller/Ticket/ListTickets.php
+++ b/api/src/Modules/registration/Controller/Ticket/ListTickets.php
@@ -206,9 +206,9 @@ class ListTickets extends BaseTicketInclude
             $aid = $user;
         }
 
-        if ($user != $aid &&
-            !$this->container->RBAC::havePermission('api.registration.ticket.list')) {
-            throw new PermissionDeniedException();
+        if ($user != $aid) {
+            $permissions = ['api.registration.ticket.list'];
+            $this->checkPermissions($permissions);
         }
 
         $select = Select::new($this->container->db)

--- a/api/src/Modules/registration/Settings.php
+++ b/api/src/Modules/registration/Settings.php
@@ -5,5 +5,8 @@
 
 return [
 'setupRoutes' => 'setupRegistrationAPI',
-'module' => 'App\\Modules\\registration\\ModuleRegistration'
+'module' => 'App\\Modules\\registration\\ModuleRegistration',
+'baseControllers' => [
+    'App\Modules\registration\Controller\BaseRegistration'
+]
 ];

--- a/api/src/Modules/staff/Controller/BaseStaff.php
+++ b/api/src/Modules/staff/Controller/BaseStaff.php
@@ -155,6 +155,36 @@ abstract class BaseStaff extends BaseController
     }
 
 
+    public static function install($database): void
+    {
+
+    }
+
+
+    public static function permissions($database): ?array
+    {
+        $result = ['api.delete.staff.all', 'api.get.staff', 'api.post.staff.all', 'api.put.staff.all',
+            'api.delete.staff.all'];
+
+        $values = Select::new($database)
+            ->columns('DepartmentID')
+            ->from('Departments')
+            ->orderBy('`DepartmentID` ASC')
+            ->fetchAll();
+
+        foreach ($values as $value) {
+            $perm_get = 'api.get.staff.'.$value['DepartmentID'];
+            $perm_del = 'api.delete.staff.'.$value['DepartmentID'];
+            $perm_pos = 'api.post.staff.'.$value['DepartmentID'];
+            $perm_put = 'api.put.staff.'.$value['DepartmentID'];
+            $result = array_merge($result, [$perm_get, $perm_del, $perm_pos, $perm_put]);
+        }
+
+        return $result;
+
+    }
+
+
     protected function buildEntry(Request $request, $id, $dept, $member, $note, $position)
     {
         return ([

--- a/api/src/Modules/staff/Controller/BaseStaff.php
+++ b/api/src/Modules/staff/Controller/BaseStaff.php
@@ -155,7 +155,7 @@ abstract class BaseStaff extends BaseController
     }
 
 
-    public static function install($database): void
+    public static function install($container): void
     {
 
     }

--- a/api/src/Modules/staff/Controller/DeleteStaffMembership.php
+++ b/api/src/Modules/staff/Controller/DeleteStaffMembership.php
@@ -74,7 +74,7 @@ class DeleteStaffMembership extends BaseStaff
             'ListRecordID = ',
             $params['id']
         )->perform();
-        \ciab\RBAC::reload();
+        $this->container->RBAC::reload();
         return [
         \App\Controller\BaseController::RESOURCE_TYPE,
         [null],

--- a/api/src/Modules/staff/Controller/GetMemberPosition.php
+++ b/api/src/Modules/staff/Controller/GetMemberPosition.php
@@ -89,7 +89,7 @@ class GetMemberPosition extends BaseStaff
         if (array_key_exists('id', $params)) {
             $id = $this->getMember($request, $params['id'])[0]['id'];
             if ($id != $user &&
-                !\ciab\RBAC::havePermission('api.get.staff')) {
+                !$this->container->RBAC::havePermission('api.get.staff')) {
                 throw new PermissionDeniedException();
             }
             $user = $id;

--- a/api/src/Modules/staff/Controller/GetMemberPosition.php
+++ b/api/src/Modules/staff/Controller/GetMemberPosition.php
@@ -88,9 +88,9 @@ class GetMemberPosition extends BaseStaff
         $user = $request->getAttribute('oauth2-token')['user_id'];
         if (array_key_exists('id', $params)) {
             $id = $this->getMember($request, $params['id'])[0]['id'];
-            if ($id != $user &&
-                !$this->container->RBAC::havePermission('api.get.staff')) {
-                throw new PermissionDeniedException();
+            if ($id != $user) {
+                $permissions = ['api.get.staff'];
+                $this->checkPermissions($permissions);
             }
             $user = $id;
         }

--- a/api/src/Modules/staff/Controller/GetStaffMembership.php
+++ b/api/src/Modules/staff/Controller/GetStaffMembership.php
@@ -84,7 +84,7 @@ class GetStaffMembership extends BaseStaff
 
         $user = $request->getAttribute('oauth2-token')['user_id'];
         if ($data[0]['id'] != $user &&
-            !\ciab\RBAC::havePermission('api.get.staff')) {
+            !$this->container->RBAC::havePermission('api.get.staff')) {
             throw new PermissionDeniedException();
         }
 

--- a/api/src/Modules/staff/Controller/GetStaffMembership.php
+++ b/api/src/Modules/staff/Controller/GetStaffMembership.php
@@ -83,9 +83,9 @@ class GetStaffMembership extends BaseStaff
         }
 
         $user = $request->getAttribute('oauth2-token')['user_id'];
-        if ($data[0]['id'] != $user &&
-            !$this->container->RBAC::havePermission('api.get.staff')) {
-            throw new PermissionDeniedException();
+        if ($data[0]['id'] != $user) {
+            $permissions = ['api.get.staff'];
+            $this->checkPermissions($permissions);
         }
 
         return [

--- a/api/src/Modules/staff/Controller/PostStaffMembership.php
+++ b/api/src/Modules/staff/Controller/PostStaffMembership.php
@@ -129,7 +129,7 @@ class PostStaffMembership extends BaseStaff
         $event = $this->getEvent($event)['id'];
         $insert->column('EventID', $event);
         $insert->perform();
-        \ciab\RBAC::reload();
+        $this->container->RBAC::reload();
 
         $target = new GetStaffMembership($this->container);
         $data = $target->buildResource($request, $response, ['id' => $insert->getLastInsertId()])[1];

--- a/api/src/Modules/staff/Settings.php
+++ b/api/src/Modules/staff/Settings.php
@@ -6,4 +6,7 @@
 return [
 'setupRoutes' => 'setupStaffAPI',
 'module' => 'App\\Modules\\staff\\ModuleStaff',
+'baseControllers' => [
+    'App\Modules\staff\Controller\BaseStaff'
+],
 ];

--- a/api/src/Modules/volunteers/Controller/Claims/BaseClaims.php
+++ b/api/src/Modules/volunteers/Controller/Claims/BaseClaims.php
@@ -142,7 +142,7 @@ abstract class BaseClaims extends BaseController
     }
 
 
-    public static function install($database): void
+    public static function install($container): void
     {
 
     }

--- a/api/src/Modules/volunteers/Controller/Claims/BaseClaims.php
+++ b/api/src/Modules/volunteers/Controller/Claims/BaseClaims.php
@@ -142,6 +142,21 @@ abstract class BaseClaims extends BaseController
     }
 
 
+    public static function install($database): void
+    {
+
+    }
+
+
+    public static function permissions($database): ?array
+    {
+        return ['api.delete.volunteers', 'api.get.volunteer.hours',
+            'api.get.volunteer.hours', 'api.get.volunteer.claims',
+            'api.post.volunteers', 'api.put.volunteers'];
+
+    }
+
+
     protected function getReward($request, $response, $id)
     {
         $target = new \App\Modules\volunteers\Controller\Rewards\GetReward($this->container);

--- a/api/src/Modules/volunteers/Controller/Hours/BaseHours.php
+++ b/api/src/Modules/volunteers/Controller/Hours/BaseHours.php
@@ -256,6 +256,20 @@ abstract class BaseHours extends BaseController
     }
 
 
+    public static function install($database): void
+    {
+
+    }
+
+
+    public static function permissions($database): ?array
+    {
+        return ['api.delete.volunteers', 'api.get.volunteer.hours',
+            'api.post.volunteers', 'api.put.volunteers'];
+
+    }
+
+
     protected function checkOverlap($request, $memberId, $endtime, $hours, $event = null)
     {
         if ($event === null) {

--- a/api/src/Modules/volunteers/Controller/Hours/BaseHours.php
+++ b/api/src/Modules/volunteers/Controller/Hours/BaseHours.php
@@ -256,7 +256,7 @@ abstract class BaseHours extends BaseController
     }
 
 
-    public static function install($database): void
+    public static function install($container): void
     {
 
     }

--- a/api/src/Modules/volunteers/Controller/Rewards/BaseReward.php
+++ b/api/src/Modules/volunteers/Controller/Rewards/BaseReward.php
@@ -108,7 +108,7 @@ abstract class BaseReward extends BaseController
     }
 
 
-    public static function install($database): void
+    public static function install($container): void
     {
 
     }

--- a/api/src/Modules/volunteers/Controller/Rewards/BaseReward.php
+++ b/api/src/Modules/volunteers/Controller/Rewards/BaseReward.php
@@ -108,6 +108,19 @@ abstract class BaseReward extends BaseController
     }
 
 
+    public static function install($database): void
+    {
+
+    }
+
+
+    public static function permissions($database): ?array
+    {
+        return ['api.delete.volunteers', 'api.post.volunteers', 'api.put.volunteers'];
+
+    }
+
+
     protected function getClaimed($id)
     {
         $data = Select::new($this->container->db)

--- a/api/src/Modules/volunteers/Controller/Rewards/BaseRewardGroup.php
+++ b/api/src/Modules/volunteers/Controller/Rewards/BaseRewardGroup.php
@@ -94,7 +94,7 @@ abstract class BaseRewardGroup extends BaseController
     }
 
 
-    public static function install($database): void
+    public static function install($container): void
     {
 
     }

--- a/api/src/Modules/volunteers/Controller/Rewards/BaseRewardGroup.php
+++ b/api/src/Modules/volunteers/Controller/Rewards/BaseRewardGroup.php
@@ -94,6 +94,19 @@ abstract class BaseRewardGroup extends BaseController
     }
 
 
+    public static function install($database): void
+    {
+
+    }
+
+
+    public static function permissions($database): ?array
+    {
+        return null;
+
+    }
+
+
     protected function getClaimed($id)
     {
         $data = Select::new($this->container->db)

--- a/api/src/Modules/volunteers/ModuleVolunteers.php
+++ b/api/src/Modules/volunteers/ModuleVolunteers.php
@@ -17,7 +17,7 @@ class ModuleVolunteers extends BaseModule
     public function __construct($source)
     {
         parent::__construct($source);
-        \ciab\RBAC::customizeRBAC('\App\Modules\volunteers\ModuleVolunteers::customizeAnnouncementRBAC');
+        $source->getContainer()->RBAC::customizeRBAC('\App\Modules\volunteers\ModuleVolunteers::customizeAnnouncementRBAC');
 
     }
 

--- a/api/src/Modules/volunteers/ModuleVolunteers.php
+++ b/api/src/Modules/volunteers/ModuleVolunteers.php
@@ -36,11 +36,10 @@ class ModuleVolunteers extends BaseModule
     }
 
 
-    public function customizeAnnouncementRBAC($instance, $database)
+    public function customizeAnnouncementRBAC($rbac, $database)
     {
-        $role = $instance->getRole('all.staff');
-        $role->addPermission('api.post.volunteers');
-        $role->addPermission('api.get.volunteer.hours');
+        $rbac->grantPermission('all.staff', 'api.post.volunteers');
+        $rbac->grantPermission('all.staff', 'api.get.volunteer.hours');
 
         $positions = [];
         $values = Select::new($database)
@@ -60,11 +59,10 @@ class ModuleVolunteers extends BaseModule
 
         $target_h = $values['DepartmentID'].'.'.array_keys($positions)[0];
         try {
-            $role = $instance->getRole($target_h);
-            $role->addPermission('api.get.volunteer.claims');
-            $role->addPermission('api.put.volunteers');
-            $role->addPermission('api.delete.volunteers');
-            $role->addPermission('api.post.volunteers.admin');
+            $rbac->grantPermission($target_h, 'api.get.volunteer.claims');
+            $rbac->grantPermission($target_h, 'api.put.volunteer.claims');
+            $rbac->grantPermission($target_h, 'api.delete.volunteer.claims');
+            $rbac->grantPermission($target_h, 'api.post.volunteers.admin');
         } catch (Exception\InvalidArgumentException $e) {
             error_log($e);
         }

--- a/api/src/Modules/volunteers/Settings.php
+++ b/api/src/Modules/volunteers/Settings.php
@@ -6,4 +6,10 @@
 return [
 'setupRoutes' => 'setupVolunteersAPI',
 'module' => 'App\\Modules\\volunteers\\ModuleVolunteers',
+'baseControllers' => [
+    'App\Modules\volunteers\Controller\Rewards\BaseReward',
+    'App\Modules\volunteers\Controller\Rewards\BaseRewardGroup',
+    'App\Modules\volunteers\Controller\Hours\BaseHours',
+    'App\Modules\volunteers\Controller\Claims\BaseClaims'
+]
 ];

--- a/api/src/Tests/Base/CiabTestCase.php
+++ b/api/src/Tests/Base/CiabTestCase.php
@@ -21,6 +21,7 @@ require __DIR__.'/../../App/Routes.php';
 require __DIR__.'/../../App/Dependencies.php';
 require __DIR__.'/../../App/OAuth2.php';
 require __DIR__.'/../../App/Vendors.php';
+require __DIR__.'/../../App/Install.php';
 
 require __DIR__.'/../../../../functions/functions.inc';
 require_once __DIR__.'/../../../../backends/oauth2.inc';
@@ -187,6 +188,7 @@ abstract class CiabTestCase extends TestCase
                 }
             }
         }
+        setupInstall($this->container);
 
     }
 

--- a/api/src/Tests/Cases/StaffTest.php
+++ b/api/src/Tests/Cases/StaffTest.php
@@ -22,18 +22,19 @@ class StaffTest extends CiabTestCase
 
     }
 
-    
+
     public function testPutMembership(): void
-    {   
+    {
         $this->runRequest('PUT', '/member/1000/staff_membership', null, null, 400);
         $this->runRequest('PUT', '/member/-1/staff_membership', null, null, 400);
         $this->runRequest('PUT', '/member/1000/staff_membership', null, ['Nothing' => 0], 400);
         $this->runRequest('PUT', '/member/1000/staff_membership', null, ['Department' => -1, 'Position' => 1], 404);
-        $this->runRequest('PUT', '/member/1000/staff_membership', null, ['Department' => 1], 400);    
+        $this->runRequest('PUT', '/member/1000/staff_membership', null, ['Department' => 1], 400);
         $this->runRequest('PUT', '/member/1000/staff_membership', null, ['Department' => 1, 'Position' => 1, 'Note' => 'phpunitAddedNote'], 200);
         $data = $this->runSuccessJsonRequest('GET', '/member/1000/staff_membership');
         $this->assertEquals($data->data[0]->position, 'Head');
         $this->assertEquals($data->data[0]->note, 'phpunitAddedNote');
+
     }
 
 

--- a/api/src/Vendors/Stripe/BasePayment.php
+++ b/api/src/Vendors/Stripe/BasePayment.php
@@ -28,5 +28,18 @@ abstract class BasePayment extends BaseController
     }
 
 
+    public static function install($database):void
+    {
+
+    }
+
+
+    public static function permissions($database):?array
+    {
+        return null;
+
+    }
+
+
     /* End BasePayment */
 }

--- a/backends/RBAC.inc
+++ b/backends/RBAC.inc
@@ -102,5 +102,14 @@ class RBAC
     }
 
 
+    public static function registerPermissions(/*.mixed.*/$permissions)
+    {
+        if (self::instance() !== null) {
+            return self::instance()->registerPermissions($permissions);
+        }
+
+    }
+
+
     /* end class */
 }

--- a/backends/RBAC.inc
+++ b/backends/RBAC.inc
@@ -111,5 +111,59 @@ class RBAC
     }
 
 
+    public static function addRole(/*.string.*/$role, /*.array.*/$parents = null)
+    {
+        if (self::instance() !== null) {
+            return self::instance()->addRole($role, $parents);
+        }
+
+    }
+
+
+    public static function removeRole(/*.string.*/$role)
+    {
+        if (self::instance() !== null) {
+            return self::instance()->removeRole($role);
+        }
+
+    }
+
+
+    public static function addRoleParents(/*.string.*/$role, /*.array.*/$parents)
+    {
+        if (self::instance() !== null) {
+            return self::instance()->addRoleParents($role, $parents);
+        }
+
+    }
+
+
+    public static function removeRoleParent(/*.string.*/$role, /*.string.*/$parent)
+    {
+        if (self::instance() !== null) {
+            return self::instance()->removeRoleParent($role, $parent);
+        }
+
+    }
+
+
+    public static function grantPermission(/*.string.*/$role, /*.string.*/$permission)
+    {
+        if (self::instance() !== null) {
+            return self::instance()->grantPermission($role, $permission);
+        }
+
+    }
+
+
+    public static function revokePermission(/*.string.*/$role, /*.string.*/$permission)
+    {
+        if (self::instance() !== null) {
+            return self::instance()->revokePermission($role, $permission);
+        }
+
+    }
+
+
     /* end class */
 }

--- a/modules/concom/functions/RBAC.inc
+++ b/modules/concom/functions/RBAC.inc
@@ -44,15 +44,12 @@ class ConComRBAC
 
 
     private static function addToAll(
-        /*.Rbac.*/$rbac,
-        /*.Role.*/$staff,
+        /*.string.*/$staff,
         /*.string.*/$new_role,
         /*.string.*/$pos
     ) {
-        $role = $rbac->rbac->getRole($new_role);
-        $staff->addParent($role);
-        $target = $rbac->rbac->getRole("all.$pos");
-        $target->addParent($role);
+        self::addRoleParents($staff, [$new_role]);
+        self::addRoleParents("all.$pos", [$new_role]);
 
     }
 
@@ -62,12 +59,10 @@ class ConComRBAC
         if (self::$instance === null) {
             $rbac = new ConComRBAC();
             $rbac->rbac = new Rbac();
+            self::$instance = $rbac;
 
-            $root = new Role('admin');
-            $rbac->rbac->addRole($root);
-
-            $staff = new Role('all.staff');
-            $rbac->rbac->addRole($staff, $root);
+            self::addRole('admin');
+            self::addRole('all.staff', 'admin');
 
             $positions = [];
             $sql = "SELECT `PositionID` FROM `ConComPositions` ORDER BY `PositionID` ASC";
@@ -77,7 +72,7 @@ class ConComRBAC
             while ($value !== false) {
                 $positions[] = $value['PositionID'];
                 $new = 'all.'.$value['PositionID'];
-                $rbac->rbac->addRole($new, $parent);
+                self::addRole($new, [$parent]);
                 $parent = $new;
                 $value = $result->fetch();
             }
@@ -89,8 +84,8 @@ class ConComRBAC
                 $parent = 'admin';
                 foreach ($positions as $pos) {
                     $new = $value['DepartmentID'].'.'.$pos;
-                    $rbac->rbac->addRole($new, $parent);
-                    self::addToAll($rbac, $staff, $new, $pos);
+                    self::addRole($new, [$parent]);
+                    self::addToAll('all.staff', $new, $pos);
                     $parent = $new;
                 }
                 $value = $result->fetch();
@@ -104,8 +99,8 @@ class ConComRBAC
                 $parent = $firstparent;
                 foreach ($positions as $pos) {
                     $new = $value['DepartmentID'].'.'.$pos;
-                    $rbac->rbac->addRole($new, $parent);
-                    self::addToAll($rbac, $staff, $new, $pos);
+                    self::addRole($new, [$parent]);
+                    self::addToAll('all.staff', $new, $pos);
                     if ($parent == $firstparent) {
                         $parent = $new;
                     }
@@ -120,8 +115,7 @@ class ConComRBAC
             $retvalue = [];
             while ($value !== false) {
                 try {
-                    $role = $rbac->rbac->getRole(strval($value['Position']));
-                    $role->addPermission($value['Permission']);
+                    self::$instance->grantPermission(strval($value['Position']), $value['Permission']);
                 } catch (Exception\InvalidArgumentException $e) {
                 }
                 if (!in_array($value['Permission'], self::$instance->permissions)) {
@@ -129,8 +123,6 @@ class ConComRBAC
                 }
                 $value = $result->fetch();
             }
-
-            self::$instance = $rbac;
         }
 
         return self::$instance;
@@ -229,7 +221,7 @@ class ConComRBAC
     public static function customizeRBAC($entry)
     {
         try {
-            @\call_user_func($entry, self::instance()->rbac, \DB::instance());
+            @\call_user_func($entry, self::instance(), \DB::instance());
         } catch (\Exception $e) {
             error_log($e);
         }
@@ -250,6 +242,72 @@ class ConComRBAC
                 self::$instance->permissions[] = $permissions;
             }
         }
+
+    }
+
+
+    public static function addRole(/*.string.*/$role, /*.array.*/$parents = null)
+    {
+        try {
+            $r = new Role($role);
+            self::instance()->rbac->addRole($r, $parents);
+        } catch (\Exception $e) {
+            error_log($e);
+        }
+
+    }
+
+
+    public static function removeRole(/*.string.*/$role)
+    {
+        /* No action in Vend/Laminas backend */
+
+    }
+
+
+    public static function addRoleParents(/*.string.*/$role, /*.array.*/$parents)
+    {
+        try {
+            $r = self::instance()->rbac->getRole($role);
+            if (!$r) {
+                self::addRole($role, $parents);
+            } else {
+                foreach($parents as $parent) {
+                    $p = self::instance()->rbac->getRole($parent);
+                    $r->addParent($p);
+                }
+            }
+        } catch (\Exception $e) {
+            error_log($e);
+        }
+
+    }
+
+
+    public static function removeRoleParent(/*.string.*/$role, /*.string.*/$parent)
+    {
+        /* No action in Vend/Laminas backend */
+
+    }
+
+
+    public static function grantPermission(/*.string.*/$role, /*.string.*/$permission)
+    {
+        try {
+            $r = self::instance()->rbac->getRole($role);
+            if ($r) {
+                $r->addPermission($permission);
+            }
+        } catch (\Exception $e) {
+            error_log($e);
+        }
+
+    }
+
+
+    public static function revokePermission(/*.string.*/$role, /*.string.*/$permission)
+    {
+        /* No action in Vend/Laminas backend */
 
     }
 

--- a/modules/concom/functions/RBAC.inc
+++ b/modules/concom/functions/RBAC.inc
@@ -25,6 +25,11 @@ class ConComRBAC
      */
     protected $rbac = null;
 
+    /**
+     * @var Permissions
+     */
+    protected $permissions = array();
+
 
     protected function __construct()
     {
@@ -119,6 +124,9 @@ class ConComRBAC
                     $role->addPermission($value['Permission']);
                 } catch (Exception\InvalidArgumentException $e) {
                 }
+                if (!in_array($value['Permission'], self::$instance->permissions)) {
+                    self::$instance->permissions[] = $value['Permission'];
+                }
                 $value = $result->fetch();
             }
 
@@ -134,6 +142,9 @@ class ConComRBAC
         /*.mixed.*/$pos,
         /*.string.*/$name
     ) {
+        if (!in_array($name, self::$instance->permissions)) {
+            error_log("Unregistered RBAC permission ".$name);
+        }
         try {
             return self::instance()->rbac->getRole(
                 strval($pos)
@@ -149,6 +160,9 @@ class ConComRBAC
         /*.mixed.*/$accountId,
         /*.string.*/$name
     ) {
+        if (!in_array($name, self::$instance->permissions)) {
+            error_log("Unregistered RBAC permission ".$name);
+        }
         if (array_key_exists('IS_ADMIN', $_SESSION) && $_SESSION['IS_ADMIN']) {
             return true;
         }
@@ -166,6 +180,9 @@ class ConComRBAC
 
     public static function havePermission(/*.string.*/$name)
     {
+        if (!in_array($name, self::$instance->permissions)) {
+            error_log("Unregistered RBAC permission ".$name);
+        }
         return self::hasPermissions($_SESSION['accountId'], $name);
 
     }
@@ -192,10 +209,7 @@ class ConComRBAC
     ) : array {
         $result = [];
         if (array_key_exists('IS_ADMIN', $_SESSION) && $_SESSION['IS_ADMIN']) {
-            foreach (self::instance()->rbac->getRoles() as $role) {
-                $result = array_unique(array_merge($result, $role->getPermissions(true)));
-            }
-            return $result;
+            return self::$instance->permissions;
         }
         $positions = POSITION::getConComPosition($accountId);
         foreach ($positions as $pos) {
@@ -218,6 +232,23 @@ class ConComRBAC
             @\call_user_func($entry, self::instance()->rbac, \DB::instance());
         } catch (\Exception $e) {
             error_log($e);
+        }
+
+    }
+
+
+    public static function registerPermissions(/*.mixed.*/$permissions)
+    {
+        if (is_array($permissions)) {
+            foreach ($permissions as $p) {
+                if (!in_array($p, self::$instance->permissions)) {
+                    self::$instance->permissions[] = $p;
+                }
+            }
+        } else {
+            if (!in_array($permissions, self::$instance->permissions)) {
+                self::$instance->permissions[] = $permissions;
+            }
         }
 
     }

--- a/modules/concom/functions/concom.inc
+++ b/modules/concom/functions/concom.inc
@@ -50,7 +50,7 @@ function getPositionID($position)
 }
 
 
-function conComRBAC($instance)
+function conComRBAC($rbac)
 {
     $positions = [];
     $sql = "SELECT `PositionID`, `Name` FROM `ConComPositions` ORDER BY `PositionID` ASC";
@@ -74,8 +74,7 @@ function conComRBAC($instance)
             $perm = "concom.modify.$dept_name.".$positions[$i];
             $target = "$parent.".end(array_keys($positions));
             try {
-                $role = $instance->getRole($target);
-                $role->addPermission($perm);
+                $rbac->grantPermission($target, $perm);
             } catch (Exception\InvalidArgumentException $e) {
                 error_log($e);
             }
@@ -84,8 +83,7 @@ function conComRBAC($instance)
         $target = "$department.$i";
         $perm = "concom.add.$dept_name";
         try {
-            $role = $instance->getRole($target);
-            $role->addPermission($perm);
+            $rbac->grantPermission($target, $perm);
         } catch (Exception\InvalidArgumentException $e) {
             error_log($e);
         }
@@ -97,8 +95,7 @@ function conComRBAC($instance)
                 $perm = "concom.modify.$dept_name.$target_pos";
                 $target = "$department.$i";
                 try {
-                    $role = $instance->getRole($target);
-                    $role->addPermission($perm);
+                    $rbac->grantPermission($target, $perm);
                 } catch (Exception\InvalidArgumentException $e) {
                     error_log($e);
                 }


### PR DESCRIPTION
Require all the pieces of the API that check RBAC permissions to register those permissions in a unified way. This will give us some more flexibility in future shifts in RBAC frameworks.

What do you think of a starting framework like this?