### PR TITLE
Additional ConCom List Updates

### DIFF
--- a/api/src/Modules/staff/ModuleStaff.php
+++ b/api/src/Modules/staff/ModuleStaff.php
@@ -8,6 +8,7 @@ namespace App\Modules\staff;
 use App\Modules\BaseModule;
 use Slim\Http\Request;
 use Slim\Http\Response;
+use Atlas\Query\Select;
 
 class ModuleStaff extends BaseModule
 {
@@ -16,6 +17,13 @@ class ModuleStaff extends BaseModule
     public function __construct($source)
     {
         parent::__construct($source);
+
+    }
+    
+
+    public function install($container)
+    {
+        $container->RBAC::customizeRBAC('\App\Modules\staff\ModuleStaff::customzieStaffRBAC');
 
     }
 
@@ -36,6 +44,65 @@ class ModuleStaff extends BaseModule
     public function handle(Request $request, Response $response, $data, $code)
     {
         return $data;
+
+    }
+
+
+    public function customzieStaffRBAC($rbac, $database)
+    {
+        $rbac->grantPermission('all.staff', 'api.get.staff');
+
+        $positions = [];
+        $values = Select::new($database)
+            ->columns('PositionID')
+            ->from('ConComPositions')
+            ->orderBy('`PositionID` ASC')
+            ->fetchAll();
+
+        foreach ($values as $value) {
+            $positions[intval($value['PositionID'])] = $value['Name'];
+        }
+
+        $values = Select::new($database)
+            ->columns('DepartmentID', 'ParentDepartmentID', 'Name')
+            ->from('Departments')
+            ->fetchAll();
+
+        foreach ($values as $value) {
+            $parentDept = $value['ParentDepartmentID'];
+            $dept = $value['DepartmentID'];
+
+            if ($parentDept != $dept) {
+                $targetRole = "$parentDept.".end(array_keys($positions));
+                try {
+                    $rbac->grantPermission($targetRole, "api.put.staff.$dept.1");
+                    $rbac->grantPermission($targetRole, "api.delete.staff.$dept.1");
+                } catch (Exception\InvalidArgumentException $e) {
+                    error_log($e);
+                }
+            }
+
+            $idx = array_keys($positions)[0];
+            try {
+                $targetRole = "$dept.$idx";
+                $rbac->grantPermission($targetRole, "api.post.staff.$dept");
+            } catch (Exception\InvalidArgumentException $e) {
+                error_log($e);
+            }
+
+            foreach ($positions as $id => $position) {
+                $currId = intval($id) + 1;
+                if (array_key_exists($currId, $positions)) {
+                    $targetRole = "$dept.$idx";
+                    try {
+                        $rbac->grantPermission($targetRole, "api.put.staff.$dept.$currId");
+                        $rbac->grantPermission($targetRole, "api.delete.staff.$dept.$currId");
+                    } catch (Exception\InvalidArgumentException $e) {
+                        error_log($e);
+                    }
+                }
+            }
+        }
 
     }
 

--- a/modules/concom/functions/RBAC.inc
+++ b/modules/concom/functions/RBAC.inc
@@ -272,7 +272,7 @@ class ConComRBAC
             if (!$r) {
                 self::addRole($role, $parents);
             } else {
-                foreach($parents as $parent) {
+                foreach ($parents as $parent) {
                     $p = self::instance()->rbac->getRole($parent);
                     $r->addParent($p);
                 }

--- a/modules/concom/sitesupport/components/staff-list.js
+++ b/modules/concom/sitesupport/components/staff-list.js
@@ -24,12 +24,12 @@ const fetchCurrentUser = async() => {
   const response = await apiRequest('GET', 'member');
   const memberData = JSON.parse(response.responseText);
 
-  const editAnyResponse = await apiRequest('GET', 'permissions/generic/staff.all/put');
-  const editAnyData = JSON.parse(editAnyResponse.responseText);
+  const userPermissions = await apiRequest('GET', `member/${memberData.id}/permissions?max_results=all`);
+  const permissionData = JSON.parse(userPermissions.responseText);
 
   return {
     id: parseInt(memberData.id),
-    editAnyAllowed: editAnyData.data[0].allowed
+    permissions: permissionData.data
   };
 };
 
@@ -71,7 +71,7 @@ const onMounted = async(componentInstance) => {
 };
 
 function componentSetup() {
-  const currentUser = Vue.ref({ id: null, editAnyAllowed: false });
+  const currentUser = Vue.ref({ id: null, permissions: [] });
   Vue.provide('currentUser', Vue.readonly(currentUser));
 
   const divisions = Vue.ref([]);


### PR DESCRIPTION
This PR includes:

- Adds RBAC to ModuleStaff in the API.
- Updates to match parity on user permissions for adding members and editing members.

What should be true for each of the positions, based on permissions:

- Admin User
  - Can add to any division or department
  - Can edit anyone in any division or department
- Division Director
  - Can add to the current division or any department within that division
  - Can edit Division Support in current division, and anyone in any department within that division
- Division Support
  - Can add to any department within that division
  - Can edit anyone in any department within that division
- Department Head
  - Can add to their department
  - Can edit sub-heads and specialists within their department
- Department Sub-Head
  - Cannot add to their department
  - Cannot edit anyone within their department
- Department Specialist
  - Cannot add to their department
  - Cannot edit anyone within their department

Next up, for future PRs:
- Need to confirm the behavior of the Sidebar in old vs new. Want to see if the RBAC stuff limits what shows in the dropdown (not sure if it does or doesn't). For example, can or should a department head be able to add a new department head in their department? Based on edit logic, I'd guess no.
- Fix rendered format for special divisions.
- Separate Organization Donut data from UI
