### PR TITLE
ConCom List Special Division Styles

### DIFF
--- a/modules/concom/scss/concom-list.scss
+++ b/modules/concom/scss/concom-list.scss
@@ -50,6 +50,11 @@
   @extend .CONCOM-list-row-column;
 }
 
+.CONCOM-list-edit-column {
+  @extend .CONCOM-list-row-column;
+  width: 5%;
+}
+
 .CONCOM-list-separator-row-column {
   @extend .CONCOM-list-centered-row-column;
   width: 33%;
@@ -107,14 +112,19 @@
   @extend .UI-table-all;
 }
 
+.CONCOM-list-special-division-container {
+  @extend .UI-table-all;
+}
+
 .CONCOM-list-division-header-row {
   @extend .UI-table-row;
   @extend .event-color-secondary;
+  @extend .UI-center;
 }
 
 .CONCOM-list-division-header-column {
   @extend .CONCOM-list-centered-row-column;
-  width: 16.66%;
+  width: 20%;
 }
 
 .CONCOM-list-department-header-row {
@@ -125,21 +135,40 @@
 
 .CONCOM-list-department-header-column {
   @extend .CONCOM-list-centered-row-column;
-  width: 12.5%;
+  width: 13.5%;
+}
+
+.CONCOM-list-special-division-header-row {
+  @extend .UI-table-row;
+  @extend .event-color-secondary;
+}
+
+.CONCOM-list-special-division-header-column {
+  @extend .CONCOM-list-centered-row-column;
+  width: 20%;
 }
 
 .CONCOM-list-staff-container {
   @extend .UI-table-row;
 }
 
+.CONCOM-list-special-division-staff-container {
+  @extend .UI-table-row;
+}
+
 .CONCOM-list-division-staff-column {
   @extend .CONCOM-list-centered-row-column;
-  width: 16.66%;
+  width: 20%;
 }
 
 .CONCOM-list-department-staff-column {
   @extend .CONCOM-list-centered-row-column;
-  width: 12.5%;
+  width: 13.5%;
+}
+
+.CONCOM-list-special-division-staff-column {
+  @extend .CONCOM-list-centered-row-column;
+  width: 20%;
 }
 
 .CONCOM-list-sidebar-container {

--- a/modules/concom/sitesupport/components/department-header.js
+++ b/modules/concom/sitesupport/components/department-header.js
@@ -1,20 +1,33 @@
 /* globals Vue */
 const PROPS = {
   isDepartment: Boolean,
+  isSpecialDivision: Boolean,
+  isCorporateDivision: Boolean,
   department: Object
 }
 
 const TEMPLATE = `
   <div :class="headerClass(isDepartment).value" :id="'table_header_' + htmlTagFriendlyName(department).value">
-    <div :class="columnClass(isDepartment).value" v-if="isDepartment">Department</div>
-    <div :class="columnClass(isDepartment).value" v-if="isDepartment">Division</div>
-    <div :class="columnClass(isDepartment).value" v-if="!isDepartment">Division</div>
-    <div :class="columnClass(isDepartment).value">Name</div>
-    <div :class="columnClass(isDepartment).value">Pronouns</div>
-    <div :class="columnClass(isDepartment).value">Position</div>
-    <div :class="columnClass(isDepartment).value" v-if="isDepartment">Email</div>
-    <div :class="columnClass(isDepartment).value">Note</div>
-    <div :class="columnClass(isDepartment).value"></div>
+    <template v-if="isSpecialDivision">
+      <div class="CONCOM-list-special-division-header-column" v-if="!isCorporateDivision">Division</div>
+      <div class="CONCOM-list-special-division-header-column" v-if="isCorporateDivision">Role</div>
+      <div class="CONCOM-list-special-division-header-column">Name</div>
+      <div class="CONCOM-list-special-division-header-column">Pronouns</div>
+      <div class="CONCOM-list-special-division-header-column">Email</div>
+      <div class="CONCOM-list-special-division-header-column">Note</div>
+      <div class="CONCOM-list-edit-column"></div>
+    </template>
+    <template v-else>
+      <div :class="columnClass(isDepartment).value" v-if="isDepartment">Department</div>
+      <div :class="columnClass(isDepartment).value" v-if="isDepartment">Division</div>
+      <div :class="columnClass(isDepartment).value" v-if="!isDepartment">Division</div>
+      <div :class="columnClass(isDepartment).value">Name</div>
+      <div :class="columnClass(isDepartment).value">Pronouns</div>
+      <div :class="columnClass(isDepartment).value">Position</div>
+      <div :class="columnClass(isDepartment).value" v-if="isDepartment">Email</div>
+      <div :class="columnClass(isDepartment).value">Note</div>
+      <div class="CONCOM-list-edit-column"></div>
+    </template>
   </div>
 `;
 
@@ -22,8 +35,12 @@ const htmlTagFriendlyName = (department) => Vue.computed(() => {
   return department.name.replaceAll(' ', '_');
 });
 
-const headerClass = (isDepartment) => Vue.computed(() => {
-  return isDepartment ? 'CONCOM-list-department-header-row' : 'CONCOM-list-division-header-row';
+const headerClass = (isDepartment, isSpecialDivision) => Vue.computed(() => {
+  if (isSpecialDivision) {
+    return 'CONCOM-list-special-division-header-row';
+  } else {
+    return isDepartment ? 'CONCOM-list-department-header-row' : 'CONCOM-list-division-header-row';
+  }
 });
 
 const columnClass = (isDepartment) => Vue.computed(() => {

--- a/modules/concom/sitesupport/components/department-member.js
+++ b/modules/concom/sitesupport/components/department-member.js
@@ -1,23 +1,39 @@
 /* globals Vue */
 const PROPS = {
   staff: Object,
-  department: Object
+  department: Object,
+  isSpecialDivision: Boolean
 };
 
 const TEMPLATE = `
-  <div :class="columnClass(department).value">{{ staff.departmentName }}</div>
-  <div :class="columnClass(department).value" v-if="componentIsDept(department).value">{{ staffDivisionName(staff).value }}</div>
-  <div :class="columnClass(department).value">{{ staffFullName(staff).value }}</div>
-  <div :class="columnClass(department).value">{{ staff.pronouns }}</div>
-  <div :class="columnClass(department).value">{{ staffPosition(staff, componentIsDept(department).value).value }}</div>
-  <div :class="columnClass(department).value" v-if="componentIsDept(department).value">{{ staff.email }}</div>
-  <div :class="columnClass(department).value">
-    <p>{{staff.note}}</p>
-    <p v-if="currentUser?.id === staff.id">This is you!</p>
-  </div>
-  <div :class="columnClass(department).value">
-    <button class="CONCOM-edit-member-button" v-if="canEdit" @click="onEditClicked">Edit</button>
-  </div>
+  <template v-if="isSpecialDivision">
+    <div class="CONCOM-list-special-division-staff-column">{{ staff.departmentName }}</div>
+    <div class="CONCOM-list-special-division-staff-column">{{ staffFullName(staff).value }}</div>
+    <div class="CONCOM-list-special-division-staff-column">{{ staff.pronouns }}</div>
+    <div class="CONCOM-list-special-division-staff-column">{{ staff.email }}</div>
+    <div class="CONCOM-list-special-division-staff-column">
+      <p>{{staff.note}}</p>
+      <p v-if="currentUser?.id === staff.id">This is you!</p>
+    </div>
+    <div class="CONCOM-list-edit-column">
+      <button class="CONCOM-edit-member-button" v-if="canEdit" @click="onEditClicked">Edit</button>
+    </div>
+  </template>
+  <template v-else>
+    <div :class="columnClass(department).value">{{ staff.departmentName }}</div>
+    <div :class="columnClass(department).value" v-if="componentIsDept(department).value">{{ staffDivisionName(staff).value }}</div>
+    <div :class="columnClass(department).value">{{ staffFullName(staff).value }}</div>
+    <div :class="columnClass(department).value">{{ staff.pronouns }}</div>
+    <div :class="columnClass(department).value">{{ staffPosition(staff, componentIsDept(department).value).value }}</div>
+    <div :class="columnClass(department).value" v-if="componentIsDept(department).value">{{ staff.email }}</div>
+    <div :class="columnClass(department).value">
+      <p>{{staff.note}}</p>
+      <p v-if="currentUser?.id === staff.id">This is you!</p>
+    </div>
+    <div class="CONCOM-list-edit-column">
+      <button class="CONCOM-edit-member-button" v-if="canEdit" @click="onEditClicked">Edit</button>
+    </div>
+  </template>
 `;
 
 const columnClass = (department) => Vue.computed(() => {
@@ -58,7 +74,7 @@ const canEditDepartmentStaff = (departmentId, permissions, staffPosition) => {
 function onEditClicked() {
   const emittedEventData = {
     staff: this.staff,
-    isDepartment: this.isDepartment
+    isDepartment: this.componentIsDept(this.department).value
   };
 
   this.$emit('editClicked', emittedEventData);

--- a/modules/concom/sitesupport/components/staff-department.js
+++ b/modules/concom/sitesupport/components/staff-department.js
@@ -17,10 +17,12 @@ const TEMPLATE = `
       </div>
     </div>
   </div>
-  <div :class="tableClass(department).value">
-    <department-header :isDepartment=isDepartment(department).value :department=department></department-header>
-    <div class="CONCOM-list-staff-container" v-for="staff in departmentStaff">
-      <department-member :staff=staff :department=department @edit-clicked="editStaffClicked"></department-member>
+  <div :class="tableClass(department, division).value">
+    <department-header :isDepartment=isDepartment(department).value :department=department
+      :isSpecialDivision=division.specialDivision :isCorporateDivision="isCorporateDivision(division).value"></department-header>
+    <div :class="staffContainerClass(division).value" v-for="staff in departmentStaff">
+      <department-member :staff=staff :department=department :isSpecialDivision=division.specialDivision
+        @edit-clicked="editStaffClicked"></department-member>
     </div>
   </div>
   <div class="CONCOM-add-member-button-container">
@@ -36,8 +38,20 @@ const divisionNavigationRef = (division) => Vue.computed(() => {
   return `#${division.name}`
 });
 
-const tableClass = (department) => Vue.computed(() => {
-  return isDepartment(department).value ? 'CONCOM-list-department-container' : 'CONCOM-list-division-container';
+const tableClass = (department, division) => Vue.computed(() => {
+  if (division.specialDivision) {
+    return 'CONCOM-list-special-division-container';
+  } else {
+    return isDepartment(department).value ? 'CONCOM-list-department-container' : 'CONCOM-list-division-container';
+  }
+});
+
+const staffContainerClass = (division) => Vue.computed(() => {
+  return division.specialDivision ? 'CONCOM-list-special-division-staff-container' : 'CONCOM-list-staff-container';
+});
+
+const isCorporateDivision = (division) => Vue.computed(() => {
+  return division.name === 'Corporate Staff';
 });
 
 const filterStaff = (staff, staffPositions, department) => {
@@ -52,15 +66,6 @@ const filterStaff = (staff, staffPositions, department) => {
   }
 
   return staff;
-};
-
-const INITIAL_DATA = () => {
-  return {
-    isDepartment,
-    divisionNavigationRef,
-    tableClass,
-    filterStaff
-  }
 };
 
 const canAddDepartmentStaff = (departmentId, permissions) => {
@@ -134,7 +139,6 @@ function componentSetup(props) {
 const staffDepartmentComponent = {
   props: PROPS,
   template: TEMPLATE,
-  data: INITIAL_DATA,
   setup: componentSetup,
   mounted() {
     const departmentId = this.department.id;
@@ -144,7 +148,13 @@ const staffDepartmentComponent = {
   methods: {
     addStaffClicked,
     editStaffClicked,
-    updateSidebarProps
+    updateSidebarProps,
+    isDepartment,
+    divisionNavigationRef,
+    tableClass,
+    staffContainerClass,
+    filterStaff,
+    isCorporateDivision
   }
 };
 

--- a/modules/concom/sitesupport/components/staff-division.js
+++ b/modules/concom/sitesupport/components/staff-division.js
@@ -38,8 +38,6 @@ const divisionName = (division) => Vue.computed(() => {
 const INITIAL_DATA = () => {
   return {
     divisionStaffMap: {},
-    htmlTagFriendlyName,
-    divisionName
   }
 };
 
@@ -72,6 +70,10 @@ const staffDivisionComponent = {
   data: INITIAL_DATA,
   async mounted() {
     await onMounted(this);
+  },
+  methods: {
+    htmlTagFriendlyName,
+    divisionName
   }
 };
 


### PR DESCRIPTION
This PR includes additional styling changes for special divisions such as Committees and Corporate Staff.

- Adds new specific styles for the special divisions so we can easily change only those later.
- Component updates with templates using conditional rendering for special divisions compared with regular ones
- Component updates for consistency with `methods` definitions

This addresses an issue with mismatched columns for some of these departments and also styles the special divisions in a way that is consistent with the other departments, rather than being half-styled.

I can't add screenshots with before and after images to the PR, but I can shared those if you'd like to see them.