### PR TITLE
ConCom List Organizational Chart

### DIFF
--- a/modules/concom/sitesupport/components/staff-division-visual.js
+++ b/modules/concom/sitesupport/components/staff-division-visual.js
@@ -1,0 +1,26 @@
+/* globals Vue, drawDonutChart */
+import { createDonutData } from '../division-parser.js';
+const PROPS = {
+  divisions: Array
+}
+
+const TEMPLATE = `
+  <div id="donut"></div>
+`;
+
+const staffDivisionVisualComponent = {
+  props: PROPS,
+  template: TEMPLATE,
+  setup(props) {
+    Vue.watchEffect(() => {
+      if (props.divisions != null && Array.isArray(props.divisions)) {
+        const donutData = createDonutData(props.divisions);
+        drawDonutChart(window.innerWidth - 50, window.innerHeight - 50, donutData, '#donut');
+      }
+    });
+
+    return {}
+  }
+};
+
+export default staffDivisionVisualComponent;

--- a/modules/concom/sitesupport/components/staff-list.js
+++ b/modules/concom/sitesupport/components/staff-list.js
@@ -6,6 +6,7 @@ const SUBHEAD_POSITION_ID = 2;
 const TEMPLATE = `
   <div :class="contentAreaClass(showSidebar).value">
     <div class="CONCOM-list-page-top-section">ConCom</div>
+    <org-donut :divisions=divisions></org-donut>
     <div class="CONCOM-list-page-content">
       <staff-division v-for="division in divisions" :division=division></staff-division>
     </div>

--- a/modules/concom/sitesupport/concom_v2.js
+++ b/modules/concom/sitesupport/concom_v2.js
@@ -7,6 +7,7 @@
 // import staffDepartmentComponent from './components/staff-department.js';
 // import staffSidebarComponent from './components/staff-sidebar.js';
 // import lookupuser from '../../../sitesupport/vue/lookupuser.js';
+// import staffDivisionVisualComponent from './components/staff-division-visual.js';
 
 const staffApp = Vue.createApp({});
 
@@ -18,6 +19,7 @@ const staffApp = Vue.createApp({});
 // staffApp.component('staff-department', staffDepartmentComponent);
 // staffApp.component('staff-sidebar', staffSidebarComponent);
 // staffApp.component('lookup-user', lookupuser);
+// staffApp.component('org-donut', staffDivisionVisualComponent);
 
 // staffApp.mount('#staff-app');
 

--- a/modules/concom/sitesupport/division-parser.js
+++ b/modules/concom/sitesupport/division-parser.js
@@ -38,6 +38,15 @@ const extractDivisions = (departmentData) => {
     }, {});
 }
 
+const remapItem = (item, idx, total) => {
+  return {
+    label: item.name,
+    colorIndex: idx,
+    link: `index.php?Function=concom#table_header_${item.name.replaceAll(' ', '_')}`,
+    dsize: (1 / total)
+  }
+};
+
 /**
  *
  * Data comes back in format as an array:
@@ -102,4 +111,89 @@ export const extractDivisionHierarchy = (departmentData) => {
   });
 
   return sortedDivisions;
+}
+
+/**
+ * Takes the sorted division data and creates the necessary structure to render our organizational hierarchy donut.
+ *
+ * Data is returned in the following format:
+ *
+ * {
+ *   "nodeData": {
+ *     "label": "Activities",
+ *     "colorIndex": 0,
+ *     "link": "index.php?function=concom#Activities",
+ *     "dsize": 1,
+ *     "strokeWidth": 3
+ *   },
+ *   "subData": [
+ *     {
+ *       "nodeData": {
+ *         "label": "arrow":,
+ *         "colorIndex": 0,
+ *         "strokeWidth": 2,
+ *         "dsize": 1,
+ *         "noRotate": 1,
+ *         "pieWidth": 10
+ *       },
+ *       "subData": [
+ *          {
+ *            "nodeData": {
+ *              "label": "Book Swap",
+ *              "colorIndex": 0,
+ *              "link": "index.php?function=concom#Book_Swap",
+ *              "dsize": 0.125,
+ *              "strokeWidth": 1
+ *            }
+ *          }
+ *       ]
+ *     }
+ *   ]
+ * }
+ *
+ * "label" is the name of the division or department, except for the arrow
+ * "colorIndex" is the color index to use when rendering, departments should match with their division
+ * "link" is the link on the ConCom List page to navigate to a section
+ * "dsize" is the area allocated to a rendered division or department. If there are 8 departments,
+ *   then each department should have a value equal to 1/8
+ * "strokeWidth" is the line width on the rendered section area
+ * @param {*} divisions
+ * @returns
+ */
+export const createDonutData = (divisions) => {
+  return divisions.map((division, idx) => {
+    const mappedDivision = {
+      // Special Case for Divisions: dsize always 1
+      ...remapItem(division, idx, 1),
+      strokeWidth: 3
+    };
+
+    // If for some reason we have additional staff in the "department" that is really the division, we don't want to double up.
+    const filteredDivisionDepts = division.departments.filter((department) => department.id !== division.id);
+    const mappedDepartments = filteredDivisionDepts.map((department) => {
+      return {
+        nodeData: {
+          ...remapItem(department, idx, filteredDivisionDepts.length),
+          strokeWidth: 1
+        }
+      }
+    });
+
+    return {
+      nodeData: mappedDivision,
+      subData: [
+        {
+          nodeData: {
+            label: '\u{233E}',
+            colorIndex: idx,
+            strokeWidth: 2,
+            dsize: 1,
+            noRotate: 1,
+            pieWidth: 10
+          },
+          subData: mappedDepartments
+        }
+      ]
+    }
+  });
 }

--- a/test/sitesupport/modules/staff/__tests__/division-parser.test.js
+++ b/test/sitesupport/modules/staff/__tests__/division-parser.test.js
@@ -1,10 +1,42 @@
 /* globals describe, it, expect */
-import { extractDivisionHierarchy } from '../../../../../modules/concom/sitesupport/division-parser';
+import { extractDivisionHierarchy, createDonutData } from '../../../../../modules/concom/sitesupport/division-parser';
 import departmentList from './department_list.json';
 
 describe('Staff Division Parser', () => {
   it('can parse the division hierarchy', () => {
     const result = extractDivisionHierarchy(departmentList.data);
     expect(result).toMatchSnapshot();
+  });
+
+  it('can parse donut data from the division data', () => {
+    const divisions = extractDivisionHierarchy(departmentList.data);
+    const result = createDonutData(divisions);
+
+    result.forEach((item, idx) => {
+      // Division at top level node data.
+      expect(item.nodeData.colorIndex).toEqual(idx);
+      expect(item.nodeData.dsize).toEqual(1);
+      expect(item.nodeData.strokeWidth).toEqual(3);
+      expect(item.nodeData).toHaveProperty('label');
+      expect(item.nodeData.link.includes(item.nodeData.label.replaceAll(' ', '_'))).toEqual(true);
+
+      const arrowNode = item.subData[0];
+      // First level of "subData" always has one element. An arrow and then departments.
+      expect(arrowNode.nodeData.colorIndex).toEqual(idx);
+      expect(arrowNode.nodeData.dsize).toEqual(1);
+      expect(arrowNode.nodeData.noRotate).toEqual(1);
+      expect(arrowNode.nodeData.pieWidth).toEqual(10);
+      expect(arrowNode.nodeData.strokeWidth).toEqual(2);
+      expect(arrowNode.nodeData.label).toEqual('⌾');
+
+      // Departments
+      arrowNode.subData.forEach((dept) => {
+        expect(dept.nodeData.colorIndex).toEqual(idx);
+        expect(dept.nodeData.dsize).toBeCloseTo((1 / arrowNode.subData.length), 5);
+        expect(dept.nodeData.strokeWidth).toEqual(1);
+        expect(dept.nodeData).toHaveProperty('label');
+        expect(dept.nodeData.link.includes(dept.nodeData.label.replaceAll(' ', '_'))).toEqual(true);
+      });
+    });
   });
 });


### PR DESCRIPTION
This PR brings the logic of the ConCom List Donut PHP Code to the front-end.

Included:
- New component for the organizational chart rendering
- New JS function to map data into the expected format for existing Donut JS function
- Leverages same division/department hierarchy data fetch code, and the Donus JS function

Did not completely swap out everything yet, but that should be next.

Next Steps:
- One more sanity check against the recent RBAC changes, then swapping in the new Vue component
- Cleaning up any PHP code that will be unused after that
- Component Library things