### PR TITLE
ConCom List Bugfixes

### DIFF
--- a/modules/concom/sitesupport/components/staff-department.js
+++ b/modules/concom/sitesupport/components/staff-department.js
@@ -118,7 +118,7 @@ function componentSetup(props) {
     if (props.divisionStaffMap != null && Array.isArray(props.divisionStaffMap[props.department.id])) {
       const staff = props.divisionStaffMap[props.department.id];
       const filteredStaff = filterStaff(staff, staffPositions.value, props.department);
-      departmentStaff.value.push(...filteredStaff);
+      departmentStaff.value = filteredStaff;
     }
   });
 

--- a/modules/concom/sitesupport/division-parser.js
+++ b/modules/concom/sitesupport/division-parser.js
@@ -22,13 +22,7 @@ const extractDivisions = (departmentData) => {
       return {
         ...mappedDivision,
         specialDivision: isSpecialDivision(item.name),
-        departments: [
-          // Special case - Divisions also have a "department" sharing the same name, so technically they are their own parent.
-          {
-            ...mappedDivision,
-            parentId: mappedDivision.id
-          }
-        ]
+        departments: []
       }
     })
     .reduce((prev, current) => {

--- a/test/sitesupport/modules/staff/__tests__/__snapshots__/division-parser.test.js.snap
+++ b/test/sitesupport/modules/staff/__tests__/__snapshots__/division-parser.test.js.snap
@@ -6,14 +6,6 @@ exports[`Staff Division Parser can parse the division hierarchy 1`] = `
     "departments": [
       {
         "email": [
-          "activities@test-con.org",
-        ],
-        "id": 1,
-        "name": "Activities",
-        "parentId": 1,
-      },
-      {
-        "email": [
           "bookswap@test-con.org",
         ],
         "id": 105,
@@ -86,14 +78,6 @@ exports[`Staff Division Parser can parse the division hierarchy 1`] = `
     "departments": [
       {
         "email": [
-          "administration@test-con.org",
-        ],
-        "id": 2,
-        "name": "Administration",
-        "parentId": 2,
-      },
-      {
-        "email": [
           "archives@test-con.org",
         ],
         "id": 102,
@@ -160,14 +144,6 @@ exports[`Staff Division Parser can parse the division hierarchy 1`] = `
     "departments": [
       {
         "email": [
-          "cfo@test-con.org",
-        ],
-        "id": 10,
-        "name": "CFO Staff",
-        "parentId": 10,
-      },
-      {
-        "email": [
           "finance@test-con.org",
         ],
         "id": 118,
@@ -215,14 +191,6 @@ exports[`Staff Division Parser can parse the division hierarchy 1`] = `
         ],
         "id": 114,
         "name": "Dealers Room",
-        "parentId": 3,
-      },
-      {
-        "email": [
-          "erac@test-con.org",
-        ],
-        "id": 3,
-        "name": "External Relations and Communications",
         "parentId": 3,
       },
       {
@@ -301,14 +269,6 @@ exports[`Staff Division Parser can parse the division hierarchy 1`] = `
       },
       {
         "email": [
-          "facilities@test-con.org",
-        ],
-        "id": 4,
-        "name": "Facilities",
-        "parentId": 4,
-      },
-      {
-        "email": [
           "hotel@test-con.org",
         ],
         "id": 125,
@@ -379,14 +339,6 @@ exports[`Staff Division Parser can parse the division hierarchy 1`] = `
         ],
         "id": 119,
         "name": "First Advisors",
-        "parentId": 5,
-      },
-      {
-        "email": [
-          "hospitality@test-con.org",
-        ],
-        "id": 5,
-        "name": "Hospitality",
         "parentId": 5,
       },
       {
@@ -489,14 +441,6 @@ exports[`Staff Division Parser can parse the division hierarchy 1`] = `
       },
       {
         "email": [
-          "productions@test-con.org",
-        ],
-        "id": 6,
-        "name": "Productions",
-        "parentId": 6,
-      },
-      {
-        "email": [
           "theaternippon@test-con.org",
         ],
         "id": 150,
@@ -529,14 +473,6 @@ exports[`Staff Division Parser can parse the division hierarchy 1`] = `
         "name": "IT",
         "parentId": 7,
       },
-      {
-        "email": [
-          "systems@test-con.org",
-        ],
-        "id": 7,
-        "name": "Systems",
-        "parentId": 7,
-      },
     ],
     "email": [
       "systems@test-con.org",
@@ -547,14 +483,6 @@ exports[`Staff Division Parser can parse the division hierarchy 1`] = `
   },
   {
     "departments": [
-      {
-        "email": [
-          "info@test-con.org",
-        ],
-        "id": 8,
-        "name": "Committees",
-        "parentId": 8,
-      },
       {
         "email": [
           "futurevisioning@test-con.org",
@@ -613,14 +541,6 @@ exports[`Staff Division Parser can parse the division hierarchy 1`] = `
   },
   {
     "departments": [
-      {
-        "email": [
-          "directors@test-con.org",
-        ],
-        "id": 9,
-        "name": "Corporate Staff",
-        "parentId": 9,
-      },
       {
         "email": [
           "president@test-con.org",


### PR DESCRIPTION
This PR includes a couple of bug fixes and one added piece of functionality.

I was able to consistently reproduce the error in `department-member` when _adding_ and _editing_ staff members to divisions. Departments seemed to be unaffected.

The root cause for this is because of the difference in position names for divisions and departments (Director, Support vs Head, Sub-Head, Specialist). In `department-member` when loading data from the server initially, all of positions are returned with `Head`, `Sub-Head` or `Specialist`, however when making updates this was not the case as Division positions were modified to render appropriately in the form, which caused behavior issues afterward.

After my changes I played around with it some more using different combinations of adding, editing, or removing staff, including multiple consecutive adds/edits/removes, and did not encounter anymore issues.

- Adds behavior that prevents a staff member from being added to the same department or division multiple times. (this was never present in the old version of the page, but was easy enough to update here)
- Fixes an issue with the rendered value on add/edit sidebar form not matching expected values for position names elsewhere.
- Fixes an issue where the current user might be added to a department, but the "This is you!" note would not be displayed.
- Fixes a component variable name that was the same as one of its function names, which could potentially cause some additional issues.
