### PR TITLE
Do not rewrite core DB values on init

### DIFF
--- a/api/src/Core/ModuleDBSchema.php
+++ b/api/src/Core/ModuleDBSchema.php
@@ -34,6 +34,8 @@ abstract class ModuleDBSchema
 
     private $database = null;
 
+    protected $forceOnInstall = true;
+
 
     public function __construct(
         /*.string.*/$field,
@@ -62,7 +64,7 @@ abstract class ModuleDBSchema
         $currentMD5 = md5(json_encode($this->schema));
 
         if ($force || $oldMD5 != $currentMD5) {
-            $force = ($force || $oldMD5 === false);
+            $force = ($force || ($this->forceOnInstall && $oldMD5 === false));
             $this->buildMissingTables($force);
 
             if ($oldMD5 !== false) {

--- a/api/src/Database/DBSchema.php
+++ b/api/src/Database/DBSchema.php
@@ -865,6 +865,7 @@ class DBSchema extends \App\Core\ModuleDBSchema
             $this->index,
             $this->seed
         );
+        $this->forceOnInstall = false;
 
     }
 


### PR DESCRIPTION
If we have existing value for these tables we need them to remain and not be changed as there are existing installs that we will be moving to this new DB code which should not be modified.