### PR TITLE
Address Performance issues on ConCom List First Page Load

### DIFF
--- a/modules/concom/scss/concom-list.scss
+++ b/modules/concom/scss/concom-list.scss
@@ -1,5 +1,3 @@
-@import "common";
-
 .CONCOM-list-page-sidebar-active {
   @extend .UI-maincontent;
   @extend .UI-mainsection-sidebar-shown;


### PR DESCRIPTION
This PR resolves the issue with slow loading on the ConCom List page the first time it is loaded if SCSS is not already cached.

Longer term, it would be nice to get this into a build process (along with JS bundling and some other pieces), but this seems to resolve things for now.

It seems like importing `common` in this file as well as `styles.scss` is likely what caused the issue with compilation speed.