### PR TITLE
DRAFT: Component Library Proof of Concept

### DIFF
--- a/modules/concom/pages/head.inc
+++ b/modules/concom/pages/head.inc
@@ -5,5 +5,7 @@
 <script src="sitesupport/donut.js"></script>
 <link rel="stylesheet" type="text/css" href="sitesupport/barcode/barcode.css" />
 <link rel="stylesheet" type="text/css" href="theme.css">
+<link rel="stylesheet" href="https://unpkg.com/vuetify@3.4.2/dist/vuetify.css">
+<link href="https://unpkg.com/@mdi/font@5.x/css/materialdesignicons.min.css" rel="stylesheet">
 <script type="module" src="modules/concom/sitesupport/division-parser.js"></script>
 <script type="module" src="modules/concom/sitesupport/concom-list.js"></script>

--- a/modules/concom/scss/concom-list.scss
+++ b/modules/concom/scss/concom-list.scss
@@ -63,14 +63,6 @@
   margin: 1em auto;
 }
 
-.CONCOM-add-member-button {
-  @extend .UI-yellowbutton;
-}
-
-.CONCOM-edit-member-button {
-  @extend .UI-redbutton;
-}
-
 .CONCOM-list-division {
   @extend .UI-container;
   @extend .UI-padding;
@@ -202,20 +194,4 @@
 .CONCOM-list-sidebar-actions-container {
   @extend .UI-center;
   @extend .UI-padding;
-}
-
-.CONCOM-list-sidebar-actions-confirm-button {
-  @extend .UI-eventbutton;
-}
-
-.CONCOM-list-sidebar-actions-modify-button {
-  @extend .UI-redbutton;
-}
-
-.CONCOM-list-sidebar-actions-cancel-button {
-  @extend .UI-redbutton;
-}
-
-.CONCOM-list-sidebar-actions-dismiss-button {
-  @extend .UI-yellowbutton;
 }

--- a/modules/concom/sitesupport/components/department-member.js
+++ b/modules/concom/sitesupport/components/department-member.js
@@ -16,7 +16,7 @@ const TEMPLATE = `
       <p v-if="currentUser?.id === staff.id">This is you!</p>
     </div>
     <div class="CONCOM-list-edit-column">
-      <button class="CONCOM-edit-member-button" v-if="canEdit" @click="onEditClicked">Edit</button>
+      <v-btn v-if="canEdit" @click="onEditClicked">Edit</v-btn>
     </div>
   </template>
   <template v-else>
@@ -31,7 +31,7 @@ const TEMPLATE = `
       <p v-if="currentUser?.id === staff.id">This is you!</p>
     </div>
     <div class="CONCOM-list-edit-column">
-      <button class="CONCOM-edit-member-button" v-if="canEdit" @click="onEditClicked">Edit</button>
+      <v-btn v-if="canEdit" @click="onEditClicked">Edit</v-btn>
     </div>
   </template>
 `;

--- a/modules/concom/sitesupport/components/staff-department.js
+++ b/modules/concom/sitesupport/components/staff-department.js
@@ -26,7 +26,7 @@ const TEMPLATE = `
     </div>
   </div>
   <div class="CONCOM-add-member-button-container">
-    <button class="CONCOM-add-member-button" @click="addStaffClicked" v-if="canAddDept">Add someone to {{department.name}}</button>
+    <v-btn @click="addStaffClicked" v-if="canAddDept">Add someone to {{department.name}}</v-btn>
   </div>
 `;
 

--- a/modules/concom/sitesupport/concom-list.js
+++ b/modules/concom/sitesupport/concom-list.js
@@ -1,4 +1,4 @@
-/* globals Vue, showSpinner, hideSpinner */
+/* globals Vue, showSpinner, hideSpinner, Vuetify */
 import staffListComponent from './components/staff-list.js';
 import sectionNavComponent from './components/staff-section-nav.js';
 import staffDivisionComponent from './components/staff-division.js';
@@ -13,6 +13,38 @@ function updateLoading() {
   this.isLoading = !this.isLoading;
   this.isLoading ? showSpinner() : hideSpinner();
 }
+
+const staffStandardTheme = {
+  dark: false,
+  colors: {
+    primary: '#620272',
+    secondary: '#00e500',
+    error: '#B00020',
+    info: '#2196F3',
+    success: '#4CAF50',
+    warning: '#FB8C00'
+  }
+}
+
+const vuetify = Vuetify.createVuetify({
+  theme: {
+    defaultTheme: 'staffStandardTheme',
+    themes: {
+      staffStandardTheme
+    }
+  },
+  defaults: {
+    VBtn: {
+      color: 'primary'
+    },
+    VSelect: {
+      variant: 'outlined'
+    },
+    VListItem: {
+      'color': 'white'
+    }
+  }
+});
 
 const staffApp = Vue.createApp({
   setup() {
@@ -29,7 +61,7 @@ const staffApp = Vue.createApp({
   methods: {
     updateLoading
   }
-});
+}).use(vuetify);
 
 staffApp.component('staff-division', staffDivisionComponent);
 staffApp.component('staff-section-nav', sectionNavComponent);

--- a/pages/base/header_start.inc
+++ b/pages/base/header_start.inc
@@ -8,7 +8,8 @@
 
 <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.11.2/css/all.css">
 <script defer src="https://use.fontawesome.com/releases/v5.11.2/js/all.js"></script>
-<script src="https://unpkg.com/vue"></script>
+<script src="https://unpkg.com/vue@3.3.8/dist/vue.global.js"></script>
+<script src="https://unpkg.com/vuetify@3.4.2/dist/vuetify.js"></script>
 <?php
 if (!function_exists('get_console') || get_console() === null) {
     echo "<script src=\"sitesupport/common.js\"></script>\n";


### PR DESCRIPTION
# The Problem

We want a way to quickly implement UI changes without some of the complexity that can exist in implementing those changes. We also want to make sure that our UI has a consistent look and feel across the application, providing a nice user experience throughout.

# Context

I explored several options for how to make general UI improvements in the CIAB site. I looked at the following options:

- [Google's Material Design](https://m3.material.io/) - this would still be a solid choice for us, however we do not use a build process (yet) which would make this a little more challenging. It makes use of Web Components, which are generally supported by all browsers.
- Briefly considered [Material UI](https://mui.com/material-ui/), but it is React only so that was a no-go.
- [Bootstrap](https://getbootstrap.com/docs/5.3/layout/containers/) - has a lot of things that work nicely out of the box. Styling is applied through using typical HTML practices such as defining something like `<div class="the-style">` so it still requires some effort. It's also incompatible with Vue, so it's a no-go.
- [Tailwind CSS](https://tailwindcss.com/) - this is _only_ CSS and also generally recommends use with a build process. Since we are looking for quick implementation for consistent look and feel, this could help in solving some of the issues around theming and consistent look and feel. However, if we wanted to build something like a date picker or color picker, we're still on our own for this.
- [Vuetify](https://vuetifyjs.com/en/) - provides nice, out of the box components for us to leverage, similar to Material Design. This framework is built to work specifically with Vue and gives us the Material Design look and feel, allows theme customization, and more.

Vuetify seems to satisfy several requirements:
- Allows us to quickly implement UI changes through pre-built components
- Allows us to quickly define styles in an application-wide theme.
- All components are rendered in the same way and can be individually customized, or inherit from the application-wide theme.
- Can be used further through our own custom component definitions.
- Can work well with build processes if we leverage that in the future.

For the purposes of this proof of concept I chose Vuetify.

# Scope
This PR includes an example implementation of some changes to our UI using Vuetify.

I chose to implement a very simple theme based on the colors on the Convergence Con site. If desired, we can also somewhat easily incorporate Material UI based Icons, and while I explored this during the example implementation, I noticed that the icons seemed to load in after the page had loaded. With additional effort we may be able to leverage these.

In this example implementation, I chose to define a thing specifically for the Staff Module, because I wanted to limit any visual changes to the ConCom List section of the site _only_. Including the CSS at the root level of the application was causing some unintended visual updates on other parts of the site. 

In practice, it is likely that we will define the theme once, in a single place and then reference that theme when we are applying the Vuetify framework into the application rather than what I have done here as an example.

# Changes Made
- Converted buttons for adding and editing to use Vuetify provided buttons.
- Converted select dropdown for position choices on the sidebar to use Vuetify provided select dropdown

I am including screenshots showing what this looked like before and how it will look after.

As you can see, there was not much that needed to be changed, we were able to simplify the code a little bit and removed some styles that were no longer needed.

This is just a simple example and does not represent fully how we can break out components our own components for further customization and re-use.

PLEASE DO NOT MERGE THIS MR. It would be nice to explore this further and convert more of this to use Vuetify if we feel this is the right path for us.

## Original Buttons and Select Style
![ConCom_Buttons_Original](https://github.com/CON-In-A-Box/CIAB-Portal/assets/10735122/4add25ab-64fb-4aa5-826e-bc7008c641c0)
![ConCom_Add_Original](https://github.com/CON-In-A-Box/CIAB-Portal/assets/10735122/7955886a-1fc9-462a-b4b9-997ca22dfe63)
![ConCom_Modify_Original](https://github.com/CON-In-A-Box/CIAB-Portal/assets/10735122/0ecb990e-333b-456b-b6a6-4fc5a1ea78e7)

## Vuetify-ed Buttons and Select Style
![ConCom_Buttons_Vuetify](https://github.com/CON-In-A-Box/CIAB-Portal/assets/10735122/2fca85ea-b7a9-45ea-a145-e7ad3ece951d)
![ConCom_Add_Vuetify](https://github.com/CON-In-A-Box/CIAB-Portal/assets/10735122/6ea2bb7e-f24d-412a-bde2-c22890a39fb8)
![ConCom_Modify_Vuetify](https://github.com/CON-In-A-Box/CIAB-Portal/assets/10735122/10088855-06ec-4018-ac2b-da54d875ae80)
