### PR TITLE
API Reorg - Proof of Concept

### DIFF
--- a/api/src/App/Dependencies.php
+++ b/api/src/App/Dependencies.php
@@ -6,6 +6,10 @@
 use Psr\Container\ContainerInterface;
 use App\Handler\ApiError;
 use App\Handler\RBAC;
+use App\Service\DepartmentService;
+use App\Service\EventService;
+use App\Mapper\EventMapper;
+use App\Mapper\StaffMapper;
 use Slim\App;
 
 /* setupAPIDependencies */
@@ -33,6 +37,18 @@ function setupAPIDependencies(App $app, array $settings)
 
     $container['RBAC'] = function (): RBAC {
         return new RBAC;
+    };
+
+    $container['department_service'] = function ($c): DepartmentService {
+        return new DepartmentService(
+            new StaffMapper($c['db'])
+        );
+    };
+
+    $container['event_service'] = function ($c): EventService {
+        return new EventService(
+            new EventMapper($c['db'])
+        );
     };
 
 }

--- a/api/src/App/Routes.php
+++ b/api/src/App/Routes.php
@@ -44,6 +44,13 @@ function setupAPIRoutes(App $app, $authMiddleware)
     )->add(new \App\Middleware\CiabMiddleware($app))->add($authMiddleware);
 
     $app->group(
+        '/divisions',
+        function () use ($app, $authMiddleware) {
+            $app->get('[/]', 'App\Controller\Department\ListDivisions');
+        }
+    )->add(new \App\Middleware\CiabMiddleware($app))->add($authMiddleware);
+
+    $app->group(
         '/deadline',
         function () use ($app, $authMiddleware) {
             $app->get('[/]', 'App\Controller\Deadline\ListMemberDeadlines');

--- a/api/src/Controller/Department/ListDivisions.php
+++ b/api/src/Controller/Department/ListDivisions.php
@@ -1,0 +1,70 @@
+<?php declare(strict_types=1);
+
+/**
+ * @OA\Get(
+ *     tags={"departments"},
+ *     path="/divisions",
+ *     summary="Lists all divisions and their departments",
+ *     @OA\Response(
+ *         response=200,
+ *         description="OK",
+ *         @OA\JsonContent(
+ *             ref="#/components/schemas/division_list"
+ *         )
+ *     ),
+ *     @OA\Response(
+ *         response=401,
+ *         ref="#/components/responses/401"
+ *     ),
+ *     security={{"ciab_auth":{}}}
+ * )
+ *
+ * @OA\Schema(
+ *    schema="division_list",
+ *    allOf = {
+ *        @OA\Schema(ref="#/components/schemas/resource_list")
+ *    },
+ *    @OA\Property(
+ *        property="type",
+ *        type="string",
+ *        enum={"division_list"}
+ *    ),
+ *    @OA\Property(
+ *        property="data",
+ *        type="array",
+ *        description="List of divisions and departments",
+ *        @OA\Items(
+ *            ref="#/components/schemas/department"
+ *        )
+ *    )
+ * )
+ */
+namespace App\Controller\Department;
+
+use Slim\Container;
+use Slim\Http\Request;
+use Slim\Http\Response;
+
+class ListDivisions
+{
+
+    protected $departmentService;
+
+
+    public function __construct(Container $container)
+    {
+        $this->departmentService = $container->get('department_service');
+
+    }
+
+
+    public function __invoke(Request $request, Response $response, $args)
+    {
+        $divisions = $this->departmentService->getStaffDivisions();
+        return $response->withJson($divisions, 200);
+
+    }
+
+
+    /* End ListDivisions */
+}

--- a/api/src/Mapper/EventMapper.php
+++ b/api/src/Mapper/EventMapper.php
@@ -1,0 +1,46 @@
+<?php declare(strict_types=1);
+
+namespace App\Mapper;
+
+use Atlas\Query\Select;
+
+class EventMapper
+{
+
+    protected $db;
+
+
+    public function __construct($db)
+    {
+        $this->db = $db;
+
+    }
+
+
+    public function getMostRecentEvent()
+    {
+        $select = Select::new($this->db);
+        return $select
+            ->columns('EventID', 'AnnualCycleID', 'DateFrom', 'DateTo', 'EventName')
+            ->from('Events')
+            ->where('Events.DateTo >= NOW()')
+            ->orderBy('Events.DateFrom ASC LIMIT 1')
+            ->fetchOne();
+
+    }
+
+
+    public function getLastActiveEvent()
+    {
+        $select = Select::new($this->db);
+        return $select
+            ->columns('EventID', 'AnnualCycleID', 'DateFrom', 'DateTo', 'EventName')
+            ->from('Events')
+            ->orderBy('Events.EventID DESC LIMIT 1')
+            ->fetchOne();
+
+    }
+
+    
+    /* End EventMapper */
+}

--- a/api/src/Mapper/StaffMapper.php
+++ b/api/src/Mapper/StaffMapper.php
@@ -1,0 +1,101 @@
+<?php declare(strict_types=1);
+
+namespace App\Mapper;
+
+use Atlas\Query\Select;
+
+class StaffMapper
+{
+
+    protected $db;
+
+
+    public function __construct($db)
+    {
+        $this->db = $db;
+
+    }
+
+
+    public function getStaffDivisions()
+    {
+        $select = Select::new($this->db);
+        $select->columns('DepartmentID as id', 'ParentDepartmentID as parent', 'Name as name', 'FallbackID as fallback')
+            ->columns(
+                $select->subSelect()
+                    ->columns('COUNT(DepartmentID)')
+                    ->from('Departments as child_depts')
+                    ->where('child_depts.ParentDepartmentID = depts.DepartmentID')
+                    ->andWhere('Name != "Historical Placeholder"')
+                    ->as('child_count')
+                    ->getStatement()
+            )
+            ->columns(
+                $select->subSelect()
+                    ->columns('GROUP_CONCAT(Email)')
+                    ->from('EMails')
+                    ->where('DepartmentID = depts.DepartmentID')
+                    ->as('email')
+                    ->getStatement()
+            )
+            ->from('Departments as depts');
+
+        $historicalPlaceholders = $select->subselect()->columns('DepartmentID')->from('Departments')->where('Name = "Historical Placeholder"');
+        $select->where('depts.DepartmentID NOT IN ', $historicalPlaceholders);
+        $select->where('depts.ParentDepartmentID NOT IN ', $historicalPlaceholders);
+
+        return $select->fetchAll();
+
+    }
+
+
+    public function getDivisionStaff($eventId, $divisionId)
+    {
+        $select = Select::new($this->db);
+
+        $historicalPlaceholder = $select->subselect()
+            ->columns('DepartmentID')
+            ->from('Departments')
+            ->where('Name = "Historical Placeholder"');
+
+        $historicalPlaceholderParents = $select->subselect()
+            ->columns('DepartmentID')
+            ->from('Departments')
+            ->where('ParentDepartmentID IN ', $historicalPlaceholder);
+
+        $depts = $select->subselect()
+            ->columns('DepartmentID')
+            ->from('Departments')
+            ->where('ParentDepartmentID = ', $divisionId);
+
+        $select
+            ->columns('Staff.ListRecordID as id', 'Staff.AccountID as member', 'Staff.DepartmentID as department')
+            ->columns('COALESCE(Staff.Note, "") as note')
+            ->columns(
+                $select->subSelect()
+                    ->columns('Name')
+                    ->from('ConComPositions')
+                    ->where('PositionID = Staff.PositionID')
+                    ->as('position')->getStatement()
+            )
+            ->columns('Depts.Name as departmentName', 'Depts.ParentDepartmentID as parentId', 'Divs.Name as parentName')
+            ->columns('(CASE WHEN Members.PreferredFirstName IS NOT NULL THEN Members.PreferredFirstName ELSE Members.FirstName END) as first_name')
+            ->columns('(CASE WHEN Members.PreferredLastName IS NOT NULL THEN Members.PreferredLastName ELSE Members.LastName END) as last_name')
+            ->columns('Members.Email as email', 'Members.Pronouns as pronouns')
+            ->from('ConComList as Staff')
+            ->join('INNER', 'Members', 'Staff.AccountID = Members.AccountID')
+            ->join('INNER', 'Departments as Depts', 'Staff.DepartmentID = Depts.DepartmentID')
+            ->join('INNER', 'Departments as Divs', 'Depts.ParentDepartmentID = Divs.DepartmentID')
+            ->where('Staff.EventID = ', $eventId)
+            ->where('Staff.DepartmentID = ', $divisionId)
+            ->orWhere('Staff.DepartmentID IN ', $depts)
+            ->where('Staff.DepartmentID NOT IN ', $historicalPlaceholder)
+            ->where('Staff.DepartmentID NOT IN ', $historicalPlaceholderParents);
+
+        return $select->fetchAll();
+
+    }
+
+
+    /* End StaffMapper */
+}

--- a/api/src/Modules/staff/App/Routes.php
+++ b/api/src/Modules/staff/App/Routes.php
@@ -33,4 +33,11 @@ function setupStaffAPI($app, $authMiddleware)
         }
     )->add(new App\Middleware\CiabMiddleware($app))->add($authMiddleware);
 
+    $app->group(
+        '/division',
+        function () use ($app, $authMiddleware) {
+            $app->get('/{id}/staff', 'App\Modules\staff\Controller\ListDivisionStaff');
+        }
+    )->add(new App\Middleware\CiabMiddleware($app))->add($authMiddleware);
+
 }

--- a/api/src/Modules/staff/Controller/ListDivisionStaff.php
+++ b/api/src/Modules/staff/Controller/ListDivisionStaff.php
@@ -1,0 +1,85 @@
+<?php declare(strict_types=1);
+/*.
+    require_module 'standard';
+.*/
+
+/**
+ *  @OA\Get(
+ *      tags={"departments"},
+ *      path="/division/{id}/staff",
+ *      summary="List staff for a division",
+ *      @OA\Parameter(
+ *          description="Division being listed",
+ *          in="path",
+ *          name="id",
+ *          required=true,
+ *          @OA\Schema(type="integer")
+ *      ),
+ *      @OA\Response(
+ *          response=200,
+ *          description="OK",
+ *          @OA\JsonContent(
+ *              ref="#/components/schemas/staff_list"
+ *          )
+ *      ),
+ *      @OA\Response(
+ *          response=401,
+ *          ref="#/components/responses/401"
+ *      ),
+ *      @OA\Response(
+ *          response=404,
+ *          description="Event or Department not found in the system.",
+ *          @OA\JsonContent(
+ *              ref="#/components/schemas/error"
+ *          )
+ *      ),
+ *      security={{"ciab_auth":{}}}
+ *  )
+ **/
+
+namespace App\Modules\staff\Controller;
+
+use Exception;
+
+use Slim\Container;
+use Slim\Http\Request;
+use Slim\Http\Response;
+
+class PermissionDeniedException extends Exception
+{
+}
+
+class ListDivisionStaff
+{
+
+    protected $rbac;
+
+    protected $eventService;
+
+    protected $departmentService;
+
+
+    public function __construct(Container $container)
+    {
+        $this->rbac = $container->get('RBAC');
+        $this->eventService = $container->get('event_service');
+        $this->departmentService = $container->get('department_service');
+
+    }
+
+
+    public function __invoke(Request $request, Response $response, $args)
+    {
+        if ($this->rbac->havePermission('api.get.staff')) {
+            $currentEvent = $this->eventService->getCurrentEvent();
+            $data = $this->departmentService->getDivisionStaff($currentEvent['id'], $args['id']);
+            return $response->withJson($data, 200);
+        } else {
+            return $response->withStatus(403);
+        }
+
+    }
+
+
+    /* End ListDivisionStaff */
+}

--- a/api/src/Service/DepartmentService.php
+++ b/api/src/Service/DepartmentService.php
@@ -1,0 +1,89 @@
+<?php declare(strict_types=1);
+
+namespace App\Service;
+
+class DepartmentService
+{
+
+    protected $staffMapper;
+
+
+    public function __construct($staffMapper)
+    {
+        $this->staffMapper = $staffMapper;
+
+    }
+
+
+    public function getStaffDivisions()
+    {
+        $data = $this->staffMapper->getStaffDivisions();
+
+        $formatted = [];
+        foreach ($data as $value) {
+            if ($value['parent'] == $value['id']) {
+                $value['parent'] = null;
+            }
+
+            if ($value['email']) {
+                $value['email'] = explode(',', $value['email']);
+            } else {
+                $value['email'] = [];
+            }
+
+            $formatted[] = $value;
+        }
+
+        return $formatted;
+
+    }
+
+
+    public function getDivisionStaff($eventId, $divisionId)
+    {
+        $data = $this->staffMapper->getDivisionStaff($eventId, $divisionId);
+
+        $formatted = [];
+        foreach ($data as $value) {
+            $member = [];
+            $member['id'] = $value['member'];
+            $member['first_name'] = $value['first_name'];
+            $member['last_name'] = $value['last_name'];
+            $member['email'] = $value['email'];
+            $member['pronouns'] = $value['pronouns'];
+
+            $value['member'] = $member;
+
+            $dept = [];
+            $dept['id'] = $value['department'];
+            $dept['name'] = $value['departmentName'];
+      
+            if ($value['department'] != $value['parentId']) {
+                $parent = [];
+                $parent['id'] = $value['parentId'];
+                $parent['name'] = $value['parentName'];
+
+                $dept['parent'] = $parent;
+            }
+
+            $value['department'] = $dept;
+
+      // Remove metadata fields that we've modified
+            unset($value['departmentName']);
+            unset($value['parentId']);
+            unset($value['parentName']);
+            unset($value['email']);
+            unset($value['first_name']);
+            unset($value['last_name']);
+            unset($value['pronouns']);
+
+            $formatted[] = $value;
+        }
+
+        return $formatted;
+
+    }
+
+
+    /* End DepartmentService */
+}

--- a/api/src/Service/EventService.php
+++ b/api/src/Service/EventService.php
@@ -1,0 +1,39 @@
+<?php declare(strict_types=1);
+
+namespace App\Service;
+
+class EventService
+{
+
+    protected $eventMapper;
+
+
+    public function __construct($eventMapper)
+    {
+        $this->eventMapper = $eventMapper;
+
+    }
+
+
+    public function getCurrentEvent()
+    {
+        $event = $this->eventMapper->getMostRecentEvent();
+        if ($event == null) {
+      // Fallback to last active event in DB
+            $event = $this->eventMapper->getLastActiveEvent();
+        }
+
+        $formatted = [];
+        $formatted['id'] = $event['EventID'];
+        $formatted['cycle'] = $event['AnnualCycleID'];
+        $formatted['date_from'] = $event['DateFrom'];
+        $formatted['date_to'] = $event['DateTo'];
+        $formatted['name'] = $event['EventName'];
+
+        return $formatted;
+
+    }
+
+
+    /* End EventService */
+}

--- a/ciab.openapi.yaml
+++ b/ciab.openapi.yaml
@@ -663,6 +663,23 @@ paths:
       security:
         -
           ciab_auth: []
+  /divisions:
+    get:
+      tags:
+        - departments
+      summary: 'Lists all divisions and their departments'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/division_list'
+        '401':
+          $ref: '#/components/responses/401'
+      security:
+        -
+          ciab_auth: []
   '/event/{id}':
     get:
       tags:
@@ -2852,6 +2869,37 @@ paths:
       security:
         -
           ciab_auth: []
+  '/division/{id}/staff':
+    get:
+      tags:
+        - departments
+      summary: 'List staff for a division'
+      parameters:
+        -
+          name: id
+          in: path
+          description: 'Division being listed'
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/staff_list'
+        '401':
+          $ref: '#/components/responses/401'
+        '404':
+          description: 'Event or Department not found in the system.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error'
+      security:
+        -
+          ciab_auth: []
   /staff:
     get:
       tags:
@@ -4127,6 +4175,22 @@ components:
                 - department_list
             data:
               description: 'List of departments'
+              type: array
+              items:
+                $ref: '#/components/schemas/department'
+        -
+          $ref: '#/components/schemas/resource_list'
+    division_list:
+      type: object
+      allOf:
+        -
+          properties:
+            type:
+              type: string
+              enum:
+                - division_list
+            data:
+              description: 'List of divisions and departments'
               type: array
               items:
                 $ref: '#/components/schemas/department'


### PR DESCRIPTION
## Context
This PR demonstrates a proof of concept to re-organize the API into a more manageable pattern by removing logic from Controllers and pushing that logic down to a Domain layer. Domain in this case refers to the "business logic" required to perform functions in the CIAB Site.

A primary concern that has been addressed with this PR is a major performance issue in which a _significant_ number of SQL queries were being executed while attempting to load the ConCom List page. When requesting and including subresource data, this was resulting in _heavy_ SQL query executions. Subresources in this case may refer to a department within a division, or a staff member within a division or department.

In our current model, including subresources in API calls for Division Staff would result in many queries, up to 2 per staff member alone. On my localhost, with around 2-3 staff members per department, for a single division **at least 99 SQL queries were executed**. I believe this is due in part to a combination of factors including: generic SQL queries that are trying to be all-encompassing and "include" actions that may trigger additional SQL calls when asking for subresource data (i.e., get list of division staff from ConComList, and now fill in member and department data - it seemed to be one at a time for each).

As you review, please ignore any specific implementation typos (such as my use of `/divisions` rather than `/division` for the list of divisions and departments)

## Changes
The changes included represent a shift in design to follow a format that breaks logic up into different logical layers, which helps to keep our Controllers simple and allows us to more easily test our business logic.

In following the new design, I have split out the logic from the Controller into a "Service" and a "Mapper". The Controller will call the appropriate "Service" layer, which may make calls to the "Mapper" layer. These have been added to the Slim Container, so that they can be used as injected dependencies similar to our Database and RBAC code.

The "Service" layer represents "business logic" that may be executed during a request. If we need to format data coming from the database, that would happen here. If we need to format data coming from the UI to match what the database expects before inserting it, that would also happen here. If we need to do any data aggregation or anything else that you might expect from an API, that logic would happen here.

The "Mapper" layer represents calls to the data sources directly. This is sometimes also called a "Repository" layer and we could use that name if we prefer, I was simply following the naming conventions on the Slim documentation. This layer is responsible for fetching data from our Database, from other REST APIs, the filesystem, etc.

I have introduced two new controllers that are specifically dedicated to two functions:
- Get a list of divisions and departments
- Get a list of staff for a given division and its departments

Requesting the staff for a given division in this new implementation has reduced the number of SQL queries down to less than 5 total. Realistically, I think it will be 2-3 in most cases.

API Calls used for Testing:
- `/api/department/`
- `/api/department/{id}/staff?subdepartments=1`
- `/api/divisions`
- `/api/division/{id}/staff` (no need to ask for subdepartments, it is assumed)

While I think the overall concept is demonstrated here, feel free to call out anything that I have missed as far as PHP best practices. I'm still quite unfamiliar with what options are available to get done what I've done here.

## Caveats
- I spent a bit of time investigating our SQL Query usage, and used `EXPLAIN` on our generated queries to figure out if there are additional optimizations we can make there
- I added an index in my SQL database on the `Departments` table (`CREATE INDEX idx_Name ON Departments (Name);`), but I have no idea how we will add this in production currently unless it is just manual.
- I did verify that the data coming from the new and old requests match up for the fields I specifically cared to implement and check against
  - I did this with a JS test suite that I did not include with this PR, comparing against JSON data directly from the APIs I changed
- I did not include PHP tests with these changes
  - The Service Layer can now easily be given a mock implementation that returns consistent data we can test against _without_ needing to connect to a database.
  - We can still test end to end by calling the API directly and connecting to the database as we had done previously
- I only verified against data I had on my local machine
  - One division was used for sampling and proving out the concept. It has 33 staff in the division and related departments.
  - Only one event exists in my database