### PR TITLE
ConCom List Organizational Donut Rendering Issue

### DIFF
--- a/modules/concom/sitesupport/division-parser.js
+++ b/modules/concom/sitesupport/division-parser.js
@@ -45,21 +45,23 @@ const prepareDonutData = (divisions) => {
     return memo;
   }, {});
 
-  // Fallback division data is effectively a linked list.
-  let divisionToAdd = divisions.filter((division) => division.fallback != null)?.[0];
+  const divisionsToAdd = divisions.filter((division) => division.fallback != null);
+
   let donutDivisionData = [];
-
   let addedDivisionNames = [];
-  while (divisionToAdd?.fallback != null && !addedDivisionNames.includes(divisionToAdd.name)) {
-    donutDivisionData.push(divisionToAdd);
-    addedDivisionNames.push(divisionToAdd.name);
+  for (const division of divisionsToAdd) {
+    if (!addedDivisionNames.includes(division.name)) {
+      donutDivisionData.push(division);
+      addedDivisionNames.push(division.name);
+    }
 
-    divisionToAdd = divisionMap[divisionToAdd.fallback];
-  }
+    let fallback = divisionMap[division.fallback];
+    while (fallback != null && !addedDivisionNames.includes(fallback.name)) {
+      donutDivisionData.push(fallback);
+      addedDivisionNames.push(fallback.name);
 
-  if (divisionToAdd != null && !addedDivisionNames.includes(divisionToAdd.name)) {
-    donutDivisionData.push(divisionToAdd);
-    addedDivisionNames.push(divisionToAdd.name);
+      fallback = divisionMap[fallback.fallback];
+    }
   }
 
   // Add remaining divisions without fallbacks

--- a/test/sitesupport/modules/staff/__tests__/department_list_prod_sample.json
+++ b/test/sitesupport/modules/staff/__tests__/department_list_prod_sample.json
@@ -1,0 +1,133 @@
+{
+  "type": "department_list",
+  "data": [
+    {
+      "id": "1",
+      "parent": null,
+      "name": "Activities",
+      "fallback": {
+        "id": "3",
+        "name": "External Relations and Communications",
+        "type": "department"
+      },
+      "child_count": "10",
+      "email": [
+        "activities@test-con.org"
+      ]
+    },
+    {
+      "id": "2",
+      "parent": null,
+      "name": "Administration",
+      "fallback": {
+        "id": "1",
+        "name": "Activities",
+        "type": "department"
+      },
+      "child_count": "6",
+      "email": [
+        "administration@test-con.org"
+      ]
+    },
+    {
+      "id": "3",
+      "parent": null,
+      "name": "External Relations and Communications",
+      "fallback": {
+        "id": "6",
+        "name": "Productions",
+        "type": "department"
+      },
+      "child_count": "11",
+      "email": [
+        "erac@test-con.org"
+      ]
+    },
+    {
+      "id": "4",
+      "parent": null,
+      "name": "Facilities",
+      "fallback": {
+        "id": "7",
+        "name": "Systems",
+        "type": "department"
+      },
+      "child_count": "9",
+      "email": [
+        "facilities@test-con.org"
+      ]
+    },
+    {
+      "id": "5",
+      "parent": null,
+      "name": "Hospitality",
+      "fallback": {
+        "id": "4",
+        "name": "Facilities",
+        "type": "department"
+      },
+      "child_count": "11",
+      "email": [
+        "hospitality-designate@test-con.org",
+        "hospitality-designate@test-con.org",
+        "hospitality@test-con.org"
+      ]
+    },
+    {
+      "id": "6",
+      "parent": null,
+      "name": "Productions",
+      "fallback": {
+        "id": "2",
+        "name": "Administration",
+        "type": "department"
+      },
+      "child_count": "11",
+      "email": [
+        "productions@test-con.org"
+      ]
+    },
+    {
+      "id": "7",
+      "parent": null,
+      "name": "Systems",
+      "fallback": {
+        "id": "5",
+        "name": "Hospitality",
+        "type": "department"
+      },
+      "child_count": "8",
+      "email": [
+        "systems@test-con.org"
+      ]
+    },
+    {
+      "id": "8",
+      "parent": null,
+      "name": "Committees",
+      "fallback": null,
+      "child_count": "5",
+      "email": [
+        "info@test-con.org"
+      ]
+    },
+    {
+      "id": "9",
+      "parent": null,
+      "name": "Corporate Staff",
+      "fallback": null,
+      "child_count": "7",
+      "email": [
+        "directors@test-con.org"
+      ]
+    },
+    {
+      "id": "10",
+      "parent": null,
+      "name": "Board Departments",
+      "fallback": null,
+      "child_count": "4",
+      "email": []
+    }
+  ]
+}

--- a/test/sitesupport/modules/staff/__tests__/division-parser.test.js
+++ b/test/sitesupport/modules/staff/__tests__/division-parser.test.js
@@ -2,6 +2,7 @@
 import { extractDivisionHierarchy, createDonutData } from '../../../../../modules/concom/sitesupport/division-parser';
 import departmentList from './department_list.json';
 import departmentListCircular from './department_list_circular_fallback.json';
+import departmentListProd from './department_list_prod_sample.json';
 
 const verifyDonutData = (data, fallbackDepts) => {
   data.forEach((item, idx) => {
@@ -79,5 +80,12 @@ describe('Staff Division Parser', () => {
     const fallbackDeptNames = ['Activities', 'Administration', 'External Relations and Communications', 'Facilities', 'Hospitality', 'Productions',
       'Systems'];
     verifyDonutData(result, fallbackDeptNames);
+  });
+
+  it('can parse donut data from prod setup', () => {
+    const divisions = extractDivisionHierarchy(departmentListProd.data);
+    const result = createDonutData(divisions);
+
+    expect(divisions.length === result.length).toEqual(true);
   });
 });


### PR DESCRIPTION
This PR addresses an issue that could sometimes lead to some divisions not displaying in the Organizational Donut.

Maintains the current behavior in production where a division is placed as close as possible for its fallback division.