### PR TITLE
Convert Department List API to Controller -> Service -> Repo pattern

### DIFF
--- a/api/src/App/Dependencies.php
+++ b/api/src/App/Dependencies.php
@@ -6,6 +6,8 @@
 use Psr\Container\ContainerInterface;
 use App\Handler\ApiError;
 use App\Handler\RBAC;
+use App\Repository\DepartmentRepository;
+use App\Service\DepartmentService;
 use Slim\App;
 
 /* setupAPIDependencies */
@@ -33,6 +35,12 @@ function setupAPIDependencies(App $app, array $settings)
 
     $container['RBAC'] = function (): RBAC {
         return new RBAC;
+    };
+
+    $container['DepartmentService'] = function ($c): DepartmentService {
+        return new DepartmentService(
+            new DepartmentRepository($c['db'])
+        );
     };
 
 }

--- a/api/src/Controller/Department/ListDepartments.php
+++ b/api/src/Controller/Department/ListDepartments.php
@@ -34,16 +34,31 @@
 
 namespace App\Controller\Department;
 
+use Slim\Container;
 use Slim\Http\Request;
 use Slim\Http\Response;
+
+use App\Service\DepartmentService;
 
 class ListDepartments extends BaseDepartment
 {
 
+    /**
+     * @var DepartmentService
+     */
+    protected $departmentService;
+
+
+    public function __construct(Container $container)
+    {
+        parent::__construct($container);
+        $this->departmentService = $container->get("DepartmentService");
+        $this->includes = null;
+    }
 
     public function buildResource(Request $request, Response $response, $params): array
     {
-        $output = $this->getDepartment(null);
+        $output = $this->departmentService->getAllDepartments();
         return [
         \App\Controller\BaseController::LIST_TYPE,
         $output,

--- a/api/src/Repository/DepartmentRepository.php
+++ b/api/src/Repository/DepartmentRepository.php
@@ -1,0 +1,63 @@
+<?php declare(strict_types=1);
+
+namespace App\Repository;
+
+use Atlas\Query\Select;
+
+class DepartmentRepository
+{
+
+    protected $db;
+
+
+    public function __construct($db)
+    {
+        $this->db = $db;
+
+    }
+
+
+    public function findAll()
+    {
+        $select = Select::new($this->db);
+        $select->columns(
+            'depts.DepartmentID',
+            'depts.Name',
+            'parentDepts.DepartmentID as ParentID',
+            'parentDepts.Name as ParentName',
+            'fallbackDepts.DepartmentID as FallbackID',
+            'fallbackDepts.Name as FallbackName'
+        )
+            ->columns(
+                $select->subSelect()
+                    ->columns('COUNT(DepartmentID)')
+                    ->from('Departments as childDepts')
+                    ->where('childDepts.ParentDepartmentID = depts.DepartmentID')
+                    ->andWhere('Name != "Historical Placeholder"')
+                    ->as('ChildCount')
+                    ->getStatement()
+            )
+            ->columns(
+                $select->subSelect()
+                    ->columns('GROUP_CONCAT(Email)')
+                    ->from('EMails')
+                    ->where('DepartmentID = depts.DepartmentID')
+                    ->as('Email')
+                    ->getStatement()
+            )
+            ->from('Departments as depts')
+            ->join('LEFT', 'Departments as parentDepts', 'parentDepts.DepartmentID = depts.ParentDepartmentID')
+            ->join('LEFT', 'Departments as fallbackDepts', 'fallbackDepts.DepartmentID = depts.FallbackID');
+
+        $historicalPlaceholders = $select->subSelect()->columns('DepartmentID')->from('Departments')->where('Name = "Historical Placeholder"');
+
+        $select->where('depts.DepartmentID NOT IN ', $historicalPlaceholders)
+            ->where('depts.ParentDepartmentID NOT IN ', $historicalPlaceholders);
+
+        return $select->fetchAll();
+
+    }
+
+
+    /* End DepartmentRepository */
+}

--- a/api/src/Service/DepartmentService.php
+++ b/api/src/Service/DepartmentService.php
@@ -1,0 +1,66 @@
+<?php declare(strict_types=1);
+
+namespace App\Service;
+
+use App\Repository\DepartmentRepository;
+
+class DepartmentService
+{
+
+  /**
+   * @var DepartmentRepository
+   */
+    protected $departmentRepository;
+
+
+    public function __construct(DepartmentRepository $departmentRepository)
+    {
+        $this->departmentRepository = $departmentRepository;
+
+    }
+
+
+    public function getAllDepartments()
+    {
+        $result = $this->departmentRepository->findAll();
+
+        $formatted = [];
+        foreach ($result as $value) {
+            $output = [];
+            $output["id"] = $value["DepartmentID"];
+            $output["name"] = $value["Name"];
+            $output["child_count"] = $value["ChildCount"];
+            $output["type"] = "department";
+
+            if ($value["Email"]) {
+                $output["email"] = explode(',', $value["Email"]);
+            } else {
+                $output["email"] = [];
+            }
+
+            if ($value["ParentID"] && $value["ParentID"] != $value["DepartmentID"]) {
+                $output["parent"]["id"] = $value["ParentID"];
+                $output["parent"]["name"] = $value["ParentName"];
+                $output["parent"]["type"] = "department";
+            } else {
+                $output["parent"] = null;
+            }
+
+            if ($value["FallbackID"]) {
+                $output["fallback"]["id"] = $value["FallbackID"];
+                $output["fallback"]["name"] = $value["FallbackName"];
+                $output["fallback"]["type"] = "department";
+            } else {
+                $output["fallback"] = null;
+            }
+
+            $formatted[] = $output;
+        }
+
+        return $formatted;
+
+    }
+
+
+    /* End DepartmentService */
+}


### PR DESCRIPTION
This PR includes changes necessary to convert from the current inherited Controller model to the Controller -> Service -> Repository pattern.

The changes were made as a first step toward improving overall API performance for this API. I left the `buildResource` function alone for now. Once we are confident with these changes I would recommend removing `buildResource` as a fast-follow. We can also remove the `extends BaseDepartment` at that time, as it will no longer be needed.

When fetching department details I made the judgment call to supply only an ID and Name for the Parent and Fallback Department references. I figured that the data is already available in the response if more than that needs to be used.

I did not add tests, but most of that stems from lack of familiarity with testing approaches in PHP. I can spend some time on it if we'd like to get them added and include them in a follow-up MR.

With just a few sample calls, I was seeing that the response time for this endpoint was originally around 300ms on my local machine. I believe I had configured some fallback departments on my divisions.

After making these changes, the new request was typically completing around 80ms.