### PR TITLE
ConCom List Staff Performance Improvements

### DIFF
--- a/api/src/App/Dependencies.php
+++ b/api/src/App/Dependencies.php
@@ -7,7 +7,9 @@ use Psr\Container\ContainerInterface;
 use App\Handler\ApiError;
 use App\Handler\RBAC;
 use App\Repository\DepartmentRepository;
+use App\Repository\EventRepository;
 use App\Service\DepartmentService;
+use App\Service\EventService;
 use Slim\App;
 
 /* setupAPIDependencies */
@@ -40,6 +42,12 @@ function setupAPIDependencies(App $app, array $settings)
     $container['DepartmentService'] = function ($c): DepartmentService {
         return new DepartmentService(
             new DepartmentRepository($c['db'])
+        );
+    };
+
+    $container['EventService'] = function ($c): EventService {
+        return new EventService(
+            new EventRepository($c['db'])
         );
     };
 

--- a/api/src/App/Dependencies.php
+++ b/api/src/App/Dependencies.php
@@ -8,8 +8,10 @@ use App\Handler\ApiError;
 use App\Handler\RBAC;
 use App\Repository\DepartmentRepository;
 use App\Repository\EventRepository;
+use App\Repository\MemberRepository;
 use App\Service\DepartmentService;
 use App\Service\EventService;
+use App\Service\MemberService;
 use Slim\App;
 
 /* setupAPIDependencies */
@@ -48,6 +50,12 @@ function setupAPIDependencies(App $app, array $settings)
     $container['EventService'] = function ($c): EventService {
         return new EventService(
             new EventRepository($c['db'])
+        );
+    };
+
+    $container['MemberService'] = function ($c): MemberService {
+        return new MemberService(
+            new MemberRepository($c['db'])
         );
     };
 

--- a/api/src/Controller/Department/ListDepartments.php
+++ b/api/src/Controller/Department/ListDepartments.php
@@ -54,7 +54,9 @@ class ListDepartments extends BaseDepartment
         parent::__construct($container);
         $this->departmentService = $container->get("DepartmentService");
         $this->includes = null;
+
     }
+    
 
     public function buildResource(Request $request, Response $response, $params): array
     {

--- a/api/src/Modules/staff/App/Dependencies.php
+++ b/api/src/Modules/staff/App/Dependencies.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types=1);
+
+use Slim\App;
+use App\Modules\staff\Service\StaffService;
+use App\Modules\staff\Repository\StaffRepository;
+
+/* setupStaffAPIDependencies */
+
+function setupStaffAPIDependencies(App $app, array $settings)
+{
+    $container = $app->getContainer();
+
+    $container['StaffService'] = function ($c): StaffService {
+        return new StaffService(
+            $c->get('EventService'),
+            $c->get('DepartmentService'),
+            $c->get('MemberService'),
+            new StaffRepository($c['db'])
+        );
+    };
+
+}

--- a/api/src/Modules/staff/Controller/ListDepartmentStaff.php
+++ b/api/src/Modules/staff/Controller/ListDepartmentStaff.php
@@ -64,20 +64,42 @@
 
 namespace App\Modules\staff\Controller;
 
+use Slim\Container;
 use Slim\Http\Request;
 use Slim\Http\Response;
+
+use App\Handler\RBAC;
+use App\Modules\staff\Service\StaffService;
 
 class ListDepartmentStaff extends BaseStaff
 {
 
+    /**
+     * @var RBAC
+     */
+    protected $rbac;
+
+    /**
+     * @var StaffService
+     */
+    protected $staffService;
+
+
+    public function __construct(Container $container)
+    {
+        parent::__construct($container);
+        $this->rbac = $container->get("RBAC");
+        $this->staffService = $container->get("StaffService");
+        $this->includes = null;
+
+    }
+    
 
     public function buildResource(Request $request, Response $response, $params) :array
     {
         $permissions = ['api.get.staff'];
         $this->checkPermissions($permissions);
-        $event = $this->getEventId($request);
-        $sub = boolval($request->getQueryParam('subdepartments', 0));
-        $data = $this->selectStaff($event, $params['id'], null, $sub);
+        $data = $this->staffService->getStaffInDepartment($params['id']);
         return [
         \App\Controller\BaseController::LIST_TYPE,
         $data,

--- a/api/src/Modules/staff/Repository/StaffRepository.php
+++ b/api/src/Modules/staff/Repository/StaffRepository.php
@@ -1,0 +1,49 @@
+<?php declare(strict_types=1);
+
+namespace App\Modules\staff\Repository;
+
+use Atlas\Query\Select;
+
+class StaffRepository
+{
+
+    protected $db;
+
+
+    public function __construct($db)
+    {
+        $this->db = $db;
+
+    }
+
+
+    public function findStaffByDepartmentIDs($eventId, $departmentIds)
+    {
+        $select = Select::new($this->db);
+        $select->columns(
+            'Staff.ListRecordID as ListRecordID',
+            'Staff.AccountID as AccountID',
+            'Staff.DepartmentID as DepartmentID',
+            'Staff.EventID as EventID',
+            'COALESCE(Staff.Note, "") as Note',
+            'Staff.PositionID as PositionID'
+        )
+            ->columns(
+                $select->subSelect()
+                    ->columns('Name')
+                    ->from('ConComPositions')
+                    ->where('Staff.PositionID = ConComPositions.PositionID')
+                    ->as('Position')
+                    ->getStatement()
+            )
+            ->from('ConComList as Staff')
+            ->where('Staff.EventID = ', $eventId)
+            ->where('Staff.DepartmentID IN ', $departmentIds);
+
+        return $select->fetchAll();
+
+    }
+
+
+    /* End StaffRepository */
+}

--- a/api/src/Modules/staff/Service/StaffService.php
+++ b/api/src/Modules/staff/Service/StaffService.php
@@ -1,0 +1,86 @@
+<?php declare(strict_types=1);
+
+namespace App\Modules\staff\Service;
+
+use App\Service\EventService;
+use App\Service\DepartmentService;
+use App\Service\MemberService;
+use App\Modules\staff\Repository\StaffRepository;
+
+class StaffService
+{
+
+  /**
+   * @var EventService
+   */
+    protected $eventService;
+
+  /**
+   * @var DepartmentService
+   */
+    protected $departmentService;
+
+  /**
+   * @var MemberService
+   */
+    protected $memberService;
+
+  /**
+   * @var StaffRepository
+   */
+    protected $staffRepository;
+
+
+    public function __construct(
+        EventService $eventService,
+        DepartmentService $departmentService,
+        MemberService $memberService,
+        StaffRepository $staffRepository
+    ) {
+        $this->eventService = $eventService;
+        $this->departmentService = $departmentService;
+        $this->memberService = $memberService;
+        $this->staffRepository = $staffRepository;
+
+    }
+
+
+    public function getStaffInDepartment($departmentId)
+    {
+        $currentEvent = $this->eventService->getCurrentEvent();
+        $divisionDepartments = $this->departmentService->getDepartmentsById($departmentId);
+
+        $eventId = $currentEvent["id"];
+        $departmentIds = [];
+        foreach ($divisionDepartments as $department) {
+            $departmentIds[] = $department["id"];
+        }
+
+        $divisionStaff = $this->staffRepository->findStaffByDepartmentIDs($eventId, $departmentIds);
+        $accountIds = [];
+        foreach ($divisionStaff as $staff) {
+            $accountIds[] = $staff["AccountID"];
+        }
+
+        $members = $this->memberService->getMembersByIds($accountIds);
+
+        $formatted = [];
+        foreach ($divisionStaff as $staff) {
+            $output = [];
+            $output["id"] = $staff["ListRecordID"];
+            $output["positionId"] = $staff["PositionID"];
+            $output["note"] = $staff["Note"];
+            $output["position"] = $staff["Position"];
+            $output["member"] = $members[$staff["AccountID"]];
+            $output["department"] = $divisionDepartments[$staff["DepartmentID"]];
+
+            $formatted[] = $output;
+        }
+
+        return $formatted;
+
+    }
+
+
+    /* End StaffService */
+}

--- a/api/src/Modules/staff/Settings.php
+++ b/api/src/Modules/staff/Settings.php
@@ -5,6 +5,7 @@
 
 return [
 'setupRoutes' => 'setupStaffAPI',
+'setupDependencies' => 'setupStaffAPIDependencies',
 'module' => 'App\\Modules\\staff\\ModuleStaff',
 'baseControllers' => [
     'App\Modules\staff\Controller\BaseStaff'

--- a/api/src/Repository/DepartmentRepository.php
+++ b/api/src/Repository/DepartmentRepository.php
@@ -59,5 +59,23 @@ class DepartmentRepository
     }
 
 
+    public function findDepartmentsById($departmentId)
+    {
+        $select = Select::new($this->db);
+        $select->columns(
+            'depts.DepartmentID',
+            'depts.Name'
+        )
+            ->from('Departments as depts')
+            ->where('depts.Name != "Historical Placeholder"')
+            ->andWhere('(depts.DepartmentID = ', $departmentId)
+            ->catWhere(' OR depts.ParentDepartmentID = ', $departmentId)
+            ->catWhere(')');
+
+        return $select->fetchAll();
+
+    }
+
+
     /* End DepartmentRepository */
 }

--- a/api/src/Repository/EventRepository.php
+++ b/api/src/Repository/EventRepository.php
@@ -1,0 +1,60 @@
+<?php declare(strict_types=1);
+
+namespace App\Repository;
+
+use Atlas\Query\Select;
+
+class EventRepository
+{
+
+    protected $db;
+
+
+    public function __construct($db)
+    {
+        $this->db = $db;
+
+    }
+
+
+    public function getCurrentEvent()
+    {
+        $select = $this->getInitialSelect();
+        return $select->where('Events.DateTo >= NOW()')
+            ->orderBy('Events.DateFrom ASC LIMIT 1')
+            ->fetchOne();
+
+    }
+
+
+    public function getLastActiveEvent()
+    {
+        $select = $this->getInitialSelect();
+        return $select->orderBy('Events.EventID DESC LIMIT 1')
+            ->fetchOne();
+
+    }
+
+
+    private function getInitialSelect()
+    {
+        $select = Select::new($this->db);
+        $select->columns(
+            'Events.EventID as EventID',
+            'Events.DateFrom as EventFrom',
+            'Events.DateTo as EventTo',
+            'Events.EventName as EventName',
+            'AnnualCycles.AnnualCycleID as AnnualCycleID',
+            'AnnualCycles.DateFrom as AnnualCycleFrom',
+            'AnnualCycles.DateTo as AnnualCycleTo'
+        )
+            ->from('Events')
+            ->join('INNER', 'AnnualCycles', 'Events.AnnualCycleID = AnnualCycles.AnnualCycleID');
+
+        return $select;
+
+    }
+
+
+  /* End EventRepository */
+}

--- a/api/src/Repository/MemberRepository.php
+++ b/api/src/Repository/MemberRepository.php
@@ -1,0 +1,65 @@
+<?php declare(strict_types=1);
+
+namespace App\Repository;
+
+use Atlas\Query\Select;
+
+class MemberRepository
+{
+
+    protected $db;
+
+
+    public function __construct($db)
+    {
+        $this->db = $db;
+
+    }
+
+
+    public function findMembersByIds($accountIds)
+    {
+        $select = Select::new($this->db);
+        $select->columns(
+            'AccountID',
+            'FirstName as LegalFirstName',
+            'MiddleName',
+            'LastName as LegalLastName',
+            'Suffix',
+            'Email',
+            'Email2',
+            'Email3',
+            'Phone',
+            'Phone2',
+            'AddressLine1',
+            'AddressLine2',
+            'AddressCity',
+            'AddressState',
+            'AddressZipCode',
+            'AddressZipCodeSuffix',
+            'AddressCountry',
+            'AddressProvince',
+            'PreferredFirstName',
+            'PreferredLastName',
+            'Deceased',
+            'DoNotContact',
+            'EmailOptOut',
+            'Birthdate',
+            'Gender',
+            'DisplayPhone',
+            'dependentOnID as DependentOnID',
+            'Pronouns',
+            '(CASE WHEN PreferredFirstName IS NOT NULL THEN PreferredFirstName ELSE FirstName END) as FirstName',
+            '(CASE WHEN PreferredLastName IS NOT NULL THEN PreferredLastName ELSE LastName END) as LastName',
+            '(SELECT GROUP_CONCAT(AccountID SEPARATOR \', \') FROM Members sqMembers WHERE sqMembers.Email = members.Email AND NOT sqMembers.AccountID = members.AccountID) as Duplicates'
+        )
+            ->from('Members as members')
+            ->where('AccountID IN ', $accountIds);
+
+        return $select->fetchAll();
+
+    }
+
+
+    /* End MemberRepository */
+}

--- a/api/src/Service/DepartmentService.php
+++ b/api/src/Service/DepartmentService.php
@@ -26,38 +26,64 @@ class DepartmentService
 
         $formatted = [];
         foreach ($result as $value) {
-            $output = [];
-            $output["id"] = $value["DepartmentID"];
-            $output["name"] = $value["Name"];
-            $output["child_count"] = $value["ChildCount"];
-            $output["type"] = "department";
-
-            if ($value["Email"]) {
-                $output["email"] = explode(',', $value["Email"]);
-            } else {
-                $output["email"] = [];
-            }
-
-            if ($value["ParentID"] && $value["ParentID"] != $value["DepartmentID"]) {
-                $output["parent"]["id"] = $value["ParentID"];
-                $output["parent"]["name"] = $value["ParentName"];
-                $output["parent"]["type"] = "department";
-            } else {
-                $output["parent"] = null;
-            }
-
-            if ($value["FallbackID"]) {
-                $output["fallback"]["id"] = $value["FallbackID"];
-                $output["fallback"]["name"] = $value["FallbackName"];
-                $output["fallback"]["type"] = "department";
-            } else {
-                $output["fallback"] = null;
-            }
-
-            $formatted[] = $output;
+            $formatted[] = $this->formatDepartmentValue($value);
         }
 
         return $formatted;
+
+    }
+
+    
+    public function getDepartmentsById($departmentId)
+    {
+        $result = $this->departmentRepository->findDepartmentsById($departmentId);
+
+        $formatted = [];
+        foreach ($result as $value) {
+            $formattedValue = $this->formatDepartmentValue($value);
+            $formatted[$formattedValue["id"]] = $formattedValue;
+        }
+
+        return $formatted;
+
+    }
+
+
+    private function formatDepartmentValue($value)
+    {
+        $output = [];
+        $output["id"] = $value["DepartmentID"];
+        $output["name"] = $value["Name"];
+
+        if (isset($value["ChildCount"])) {
+            $output["child_count"] = $value["ChildCount"];
+        }
+        
+        $output["type"] = "department";
+
+        if (isset($value["Email"]) && $value["Email"]) {
+            $output["email"] = explode(',', $value["Email"]);
+        } else {
+            $output["email"] = [];
+        }
+
+        if (isset($value["ParentID"]) && $value["ParentID"] != $value["DepartmentID"]) {
+            $output["parent"]["id"] = $value["ParentID"];
+            $output["parent"]["name"] = $value["ParentName"];
+            $output["parent"]["type"] = "department";
+        } else {
+            $output["parent"] = null;
+        }
+
+        if (isset($value["FallbackID"])) {
+            $output["fallback"]["id"] = $value["FallbackID"];
+            $output["fallback"]["name"] = $value["FallbackName"];
+            $output["fallback"]["type"] = "department";
+        } else {
+            $output["fallback"] = null;
+        }
+
+        return $output;
 
     }
 

--- a/api/src/Service/EventService.php
+++ b/api/src/Service/EventService.php
@@ -1,0 +1,55 @@
+<?php declare(strict_types=1);
+
+namespace App\Service;
+
+use App\Repository\EventRepository;
+
+class EventService
+{
+
+  /**
+   * @var EventRepository;
+   */
+    protected $eventRepository;
+
+    protected $currentEvent = null;
+
+
+    public function __construct(EventRepository $eventRepository)
+    {
+        $this->eventRepository = $eventRepository;
+
+    }
+
+
+    public function getCurrentEvent()
+    {
+        if ($this->currentEvent != null) {
+            return $this->currentEvent;
+        }
+
+        $event = $this->eventRepository->getCurrentEvent();
+        if ($event == null) {
+      // Fallback to last active event in DB
+            $event = $this->eventRepository->getLastActiveEvent();
+        }
+
+        $formatted = [];
+        $formatted["id"] = $event["EventID"];
+        $formatted["name"] = $event["EventName"];
+        $formatted["date_from"] = $event["EventFrom"];
+        $formatted["date_to"] = $event["EventTo"];
+        $formatted["type"] = "event";
+        $formatted["cycle"]["id"] = $event["AnnualCycleID"];
+        $formatted["cycle"]["date_from"] = $event["AnnualCycleFrom"];
+        $formatted["cycle"]["date_to"] = $event["AnnualCycleTo"];
+        $formatted["cycle"]["type"] = "cycle";
+    
+        $this->currentEvent = $formatted;
+        return $formatted;
+
+    }
+
+
+    /* End EventService */
+}

--- a/api/src/Service/MemberService.php
+++ b/api/src/Service/MemberService.php
@@ -1,0 +1,68 @@
+<?php declare(strict_types=1);
+
+namespace App\Service;
+
+use App\Repository\MemberRepository;
+
+class MemberService
+{
+
+    protected $memberRepository;
+
+
+    public function __construct(MemberRepository $memberRepository)
+    {
+        $this->memberRepository = $memberRepository;
+
+    }
+
+
+    public function getMembersByIds($memberIds)
+    {
+        $result = $this->memberRepository->findMembersByIds($memberIds);
+
+        $formatted = [];
+        foreach ($result as $value) {
+            $output = [];
+            $output["id"] = $value["AccountID"];
+            $output["legal_first_name"] = $value["LegalFirstName"];
+            $output["legal_last_name"] = $value["LegalLastName"];
+            $output["middle_name"] = $value["MiddleName"];
+            $output["suffix"] = $value["Suffix"];
+            $output["email"] = $value["Email"];
+            $output["email2"] = $value["Email2"];
+            $output["email3"] = $value["Email3"];
+            $output["phone"] = $value["Phone"];
+            $output["phone2"] = $value["Phone2"];
+            $output["address_line1"] = $value["AddressLine1"];
+            $output["address_line2"] = $value["AddressLine2"];
+            $output["city"] = $value["AddressCity"];
+            $output["state"] = $value["AddressState"];
+            $output["zip_code"] = $value["AddressZipCode"];
+            $output["zip_plus4"] = $value["AddressZipCodeSuffix"];
+            $output["country"] = $value["AddressCountry"];
+            $output["province"] = $value["AddressProvince"];
+            $output["preferred_first_name"] = $value["PreferredFirstName"];
+            $output["preferred_last_name"] = $value["PreferredLastName"];
+            $output["deceased"] = $value["Deceased"];
+            $output["do_not_contact"] = $value["DoNotContact"];
+            $output["email_optout"] = $value["EmailOptOut"];
+            $output["birthdate"] = $value["Birthdate"];
+            $output["gender"] = $value["Gender"];
+            $output["concom_display_phone"] = $value["DisplayPhone"];
+            $output["dependent_on"] = $value["DependentOnID"];
+            $output["pronouns"] = $value["Pronouns"];
+            $output["first_name"] = $value["FirstName"];
+            $output["last_name"] = $value["LastName"];
+            $output["duplicates"] = $value["Duplicates"];
+
+            $formatted[$output["id"]] = $output;
+        }
+
+        return $formatted;
+
+    }
+
+
+    /* End MemberService */
+}


### PR DESCRIPTION
This PR includes performance improvement code that is built upon the Controller -> Service -> Repo pattern that was introduced in this PR: https://github.com/CON-In-A-Box/CIAB-Portal/pull/647 

This code more fully leverages the pattern and demonstrates how we can leverage it to make requests to the DB and cleanly format the response.

There are probably some additional optimizations that could be done where I am currently looping through departments and members by better use of the PHP arrays to leverage keys for the queries. After a few quick tests locally I'm not sure that it will matter too much, but we could consider it for the future.

There are no tests added for the specific service classes here, but I was able to verify the output matched between the original call and new call using JSON responses from the API and running through a JS test (not committed).

In cases where functions are added for convenience (such as `findDepartmentsById`), the full object was not pulled from the database. Instead, only enough for the API to perform the next step in its processing was retrieved and used.

I did some quick sample testing with ~33 staff as the highest in a single division and saw:

- Original Request was averaging about 335ms per request
- Updated Request was averaging about 94ms per request

I then added more staff manually to see how much of a performance boost we were getting with this as the size of staff per department increased. I tested again with 77 staff and saw these results:

- Original request for that division was 632ms for the first attempt, 580ms for the second.
- Updated request for that division was 85ms for the first attempt, 84ms for the second.

I added a few more so that I was over 100 staff in a single division and saw:

- Original request around 730ms or so
- Updated request was still 85ms