### PR TITLE
Use Sequential API requests rather than Immediate API requests

### DIFF
--- a/modules/concom/vue/concom-list.js
+++ b/modules/concom/vue/concom-list.js
@@ -9,8 +9,8 @@ import staffSidebarComponent from './staff-sidebar.js';
 import lookupuser from '../../../sitesupport/vue/lookupuser.js';
 import staffDivisionVisualComponent from './staff-division-visual.js';
 
-function updateLoading() {
-  this.isLoading = !this.isLoading;
+function updateLoading(value) {
+  this.isLoading = value;
   this.isLoading ? showSpinner() : hideSpinner();
 }
 

--- a/modules/concom/vue/staff-division.js
+++ b/modules/concom/vue/staff-division.js
@@ -1,8 +1,9 @@
-/* globals Vue, apiRequest */
-import { extractDepartmentStaff, sortStaffByPosition } from '../sitesupport/department-staff-parser.js';
+/* globals Vue */
+import { sortStaffByPosition } from '../sitesupport/department-staff-parser.js';
 
 const PROPS = {
-  division: Object
+  division: Object,
+  divisionStaff: Array
 };
 
 const TEMPLATE = `
@@ -41,16 +42,8 @@ const INITIAL_DATA = () => {
   }
 };
 
-const fetchDivisionStaff = async(divisionId) => {
-  const response = await apiRequest('GET', `department/${divisionId}/staff?subdepartments=1`);
-  const divisionStaffData = JSON.parse(response.responseText);
-  return extractDepartmentStaff(divisionStaffData.data);
-}
-
 const onMounted = async(componentInstance) => {
-  const divisionStaffResult = await fetchDivisionStaff(componentInstance.division.id);
-
-  for (const staff of divisionStaffResult) {
+  for (const staff of componentInstance.divisionStaff) {
     const deptId = `${staff.deptId}`;
     if (componentInstance.divisionStaffMap[deptId] == null) {
       componentInstance.divisionStaffMap[deptId] = [];

--- a/modules/concom/vue/staff-sidebar.js
+++ b/modules/concom/vue/staff-sidebar.js
@@ -121,7 +121,7 @@ async function onSubmit() {
 }
 
 async function editStaff(component) {
-  component.updateLoading();
+  component.updateLoading(true);
   const putData = {
     Department: component.department.id,
     Position: component.selectedPosition.id,
@@ -143,11 +143,11 @@ async function editStaff(component) {
 
     component.$emit('sidebarFormSubmitted', emittedEventData);
   }
-  component.updateLoading();
+  component.updateLoading(false);
 }
 
 async function addStaff(component) {
-  component.updateLoading();
+  component.updateLoading(true);
   const postData = {
     Department: component.department.id,
     Position: component.selectedPosition.id
@@ -179,11 +179,11 @@ async function addStaff(component) {
       component.$emit('sidebarFormSubmitted', emittedEventData);
     }
   }
-  component.updateLoading();
+  component.updateLoading(false);
 }
 
 async function onRemoveStaff() {
-  this.updateLoading();
+  this.updateLoading(true);
   const staffDeleteResponse = await apiRequest('DELETE', `staff/membership/${this.deptStaffId}`);
 
   if (staffDeleteResponse.status === 204) {
@@ -195,7 +195,7 @@ async function onRemoveStaff() {
 
     this.$emit('sidebarFormSubmitted', emittedEventData);
   }
-  this.updateLoading();
+  this.updateLoading(false);
 }
 
 function componentSetup() {


### PR DESCRIPTION
This PR includes changes to the UI for the ConCom List to make calls to fetch department staff sequentially rather than firing off all of the requests and waiting for all of them to finish.

Also defines explicit usage of the `updateLoading` function so that the spinner is displayed while loading the full list rather than flashing and then being off screen before requests have finished.