### PR TITLE
Fix an issue in MemberService

### DIFF
--- a/api/src/Service/MemberService.php
+++ b/api/src/Service/MemberService.php
@@ -19,6 +19,10 @@ class MemberService
 
     public function getMembersByIds($memberIds)
     {
+        if (count($memberIds) == 0) {
+            return [];
+        }
+
         $result = $this->memberRepository->findMembersByIds($memberIds);
 
         $formatted = [];


### PR DESCRIPTION
This PR fixes an issue that could occur when an empty array of `$memberIds` is passed into the MemberService, resulting in a SQL error when trying to execute a `WHERE AccountID IN ()` statement.

Instead, if we have no member IDs in the array, an empty array is returned.