### PR TITLE
Add ConCom Structure Page Components

### DIFF
--- a/modules/concom/vue/StaffStructureApp.js
+++ b/modules/concom/vue/StaffStructureApp.js
@@ -1,0 +1,21 @@
+/* globals Vue */
+import StaffStructurePage from './views/StaffStructurePage.js';
+import StaffStructureDivision from './components/StaffStructureDivision.js';
+import StaffSidebarDepartment from './components/StaffSidebarDepartment.js';
+import StaffSidebarDepartmentPermissions from './components/StaffSidebarDepartmentPermissions.js';
+import StaffSidebarPermissions from './components/StaffSidebarPermissions.js';
+import StaffStructureSidebar from './components/StaffStructureSidebar.js';
+import StaffSidebarEmail from './components/StaffSidebarEmail.js';
+
+const StaffStructureApp = Vue.createApp({});
+StaffStructureApp.component('staff-structure-page', StaffStructurePage);
+StaffStructureApp.component('staff-structure-division', StaffStructureDivision);
+StaffStructureApp.component('staff-sidebar-email', StaffSidebarEmail);
+StaffStructureApp.component('staff-sidebar-department', StaffSidebarDepartment);
+StaffStructureApp.component('staff-sidebar-department-permissions', StaffSidebarDepartmentPermissions);
+StaffStructureApp.component('staff-sidebar-permissions', StaffSidebarPermissions);
+StaffStructureApp.component('staff-structure-sidebar', StaffStructureSidebar);
+
+StaffStructureApp.mount('#staff-structure-app');
+
+export default StaffStructureApp;

--- a/modules/concom/vue/components/StaffSidebarDepartment.js
+++ b/modules/concom/vue/components/StaffSidebarDepartment.js
@@ -1,0 +1,78 @@
+const PROPS = {
+  edit: Boolean
+}
+
+const TEMPLATE = `
+  <div class="UI-center">
+    <h2 class="UI-red">Position Details</h2>
+  </div>
+  <div>
+    <hr/>
+    <input class="UI-hiddeninput" id="updated_dept_id" value="-1" readonly />
+    <label class="UI-label" for="updated_position_name">Position Name:</label>
+    <input class="UI-input" id="updated_dept_name" value=""/>
+    <label class="UI-label" for="updated_dept_email">Position Emails:</label>
+    <div class="UI-border" id="updated_dept_email">
+      <button class="UI-roundbutton">test@test-con.org</button>
+      <br/>
+      <button class="UI-roundbutton"><i class="fas fa-plus-square"</i></button>
+    </div>
+
+    <button class="UI-redbutton UI-padding UI-margin" id="updated_dept_rbac">
+      Position Site Permissions (RBAC)
+    </button><br/>
+
+    <label class="UI-label" for="updated_dept_count">Staff Count:</label>
+    <input class="UI-input" id="updated_dept_count" value="" readonly />
+    <div id="updated_sub_dept">
+      <label class="UI-label" for="updated_dept_sub">Sub Departments:</label>
+      <input class="UI-input" id="updated_dept_sub" value="" readonly />
+    </div>
+    <div id="updated_fallback_dept">
+      <label class="UI-label" for="updated_dept_fallback">Fallback For:</label>
+      <select class="UI-select" style="width:auto" name="Fallback" id="updated_dept_fallback"></select>
+    </div>
+    <div id="updated_parent">
+      <label class="UI-label" for="updated_dept_parent">Division:</label>
+      <select class="UI-select" style="width:auto" name="Parent" id="updated_dept_parent">
+        <option value="">Activities</option>
+        <option value="">Administration</option>
+        <option value="">CFO Staff</option>
+        <option value="">External Relations and Communications</option>
+        <option value="">Facilities</option>
+        <option value="">Hospitality</option>
+        <option value="">Productions</option>
+        <option value="">Systems</option>
+        <option value="">Committees</option>
+        <option value="">Corporate Staff</option>
+      </select>
+    </div>
+  </div>
+  <div>
+    <div id="updated_dept_slider_parent" class="UI-table switch-table UI-padding UI-center">
+      <div class="UI-table-row">
+        <div class="UI-table-cell">
+          <span class="UI-padding">Department</span>
+          <label class="switch">
+            <input id="updated_dept_slider" class="toggle" type="checkbox" />
+            <div class="slider"></div>
+          </label>
+          <span class="UI-padding">Division</span>
+        </div>
+      </div>
+    </div>
+    <div class="UI-center">
+      <hr/>
+      <button class="UI-eventbutton>Save</button>
+      <button class="UI-yellowbutton>Close</button>
+      <button class="UI-redbutton">Delete</button>
+    </div>
+  </div>
+`;
+
+const StaffSidebarDepartment = {
+  props: PROPS,
+  template: TEMPLATE
+};
+
+export default StaffSidebarDepartment;

--- a/modules/concom/vue/components/StaffSidebarDepartmentPermissions.js
+++ b/modules/concom/vue/components/StaffSidebarDepartmentPermissions.js
@@ -1,0 +1,41 @@
+const PROPS = {
+  edit: Boolean
+}
+
+const TEMPLATE = `
+  <div class="UI-center">
+    <h2 class="UI-red">Position Permissions</h2>
+  </div>
+  <div>
+    <label class="UI-label" for="updated_inherited">Inherited Permissions:</label>
+    <div id="updated_inherited" class="UI-border">
+      <span><b>Head: </b>
+        <span>site.concom.structure</span> <span>site.concom.permissions</span>
+      </span><br/>
+      <span><b>Sub-Head: </b></span><br/>
+      <span><b>Specialist: </b></span><br/>
+    </div>
+    <label class="UI-label" for="updated_present">Department Permissions:</label>
+    <div id="updated_position" class="UI-border">
+      <span><b>Head: </b>
+        <span><button class="UI-roundbutton"><i class="fas fa-plus-square"></i></button></span>
+      </span><br/>
+      <span><b>Sub-Head: </b>
+        <span><button class="UI-roundbutton"><i class="fas fa-plus-square"></i></button></span>
+      </span><br/>
+      <span><b>Specialist: </b>
+        <span><button class="UI-roundbutton"><i class="fas fa-plus-square"></i></button></span>
+      </span><br/>
+    </div>
+  </div>
+  <div class="UI-center">
+    <button class="UI-yellowbutton">Close</button>
+  </div>
+`;
+
+const StaffSidebarDepartmentPermissions = {
+  props: PROPS,
+  template: TEMPLATE
+};
+
+export default StaffSidebarDepartmentPermissions;

--- a/modules/concom/vue/components/StaffSidebarEmail.js
+++ b/modules/concom/vue/components/StaffSidebarEmail.js
@@ -1,0 +1,31 @@
+const PROPS = {
+  edit: Boolean
+}
+
+const TEMPLATE = `
+  <div class="UI-center">
+    <h2 class="UI-red">Position Email</h2>
+  </div>
+  <div>
+    <hr/>
+    <label class="UI-label" for="updated_email_email">EMail:</label>
+    <input id="updated_email_email" class="UI-input" value="test@test-con.org" />
+    <input id="updated_email_original" class="UI-hide" readonly />
+    <input id="updated_email_alias" class="UI-hide" readonly />
+    <input id="updated_email_index" class="UI-hide" readonly />
+    <input id="updated_email_dept" class="UI-hide" readonly />
+  </div>
+  <div class="UI-center">
+    <hr/>
+    <button class="UI-eventbutton">Save</button>
+    <button class="UI-yellowbutton">Close</button>
+    <button class="UI-redbutton">Delete</button>
+  </div>
+`;
+
+const StaffSidebarEmail = {
+  props: PROPS,
+  template: TEMPLATE
+};
+
+export default StaffSidebarEmail;

--- a/modules/concom/vue/components/StaffSidebarPermissions.js
+++ b/modules/concom/vue/components/StaffSidebarPermissions.js
@@ -1,0 +1,41 @@
+const TEMPLATE = `
+  <div class="UI-center">
+    <h2 class="UI-red">Add Permission</h2>
+  </div>
+  <div>
+    <hr/>
+    <select class="UI-select" style="width:auto" id="updated_perm_perm">
+      <option>admin.sudo</option>
+      <option>api.get.deadline.all</option>
+      <option>api.delete.deadline.all</option>
+      <option>api.post.deadline.all</option>
+      <option>api.put.deadline.all</option>
+      <option>asset.admin</option>
+      <option>concom.reports</option>
+      <option>concom.view</option>
+      <option>concom.modify.all</option>
+      <option>concom.add.all</option>
+      <option>registration.reports</option>
+      <option>site.admin</option>
+      <option>site.concom.permissions</option>
+      <option>site.concom.structure</option>
+      <option>site.email_lists</option>
+      <option>volunteers.admin</option>
+      <option>volunteers.reports</option>
+    </select>
+
+    <input class="UI-hide" id="updated_perm_dept" readonly />
+    <input class="UI-hide" id="updated_perm_position" readonly />
+  </div>
+  <div class="UI-center">
+    <hr/>
+    <button class="UI-eventbutton">Save</button>
+    <button class="UI-yellowbutton">Close</button>
+  </div>
+`;
+
+const StaffSidebarPermissions = {
+  template: TEMPLATE
+};
+
+export default StaffSidebarPermissions;

--- a/modules/concom/vue/components/StaffStructureDivision.js
+++ b/modules/concom/vue/components/StaffStructureDivision.js
@@ -1,0 +1,30 @@
+const TEMPLATE = `
+<div class="UI-container UI-margin">
+  <button class="CONCOM-new-division-button">
+    <span>Add New Division</span> <i class="fas fa-plus-square"></i>
+  </button>
+</div>
+
+<div class="UI-container UI-margin">
+  <span class="CONCOM-division-span">Activities</span>
+  <div class="CONCOM-division-drag-div">
+    <div class="CONCOM-department">Book Swap</div>
+    <div class="CONCOM-department">Connies Quantum Sandbox</div>
+    <div class="CONCOM-department">Exhibits</div>
+    <div class="CONCOM-department">Gaming</div>
+    <div class="CONCOM-department">Invited Participants</div>
+    <div class="CONCOM-department">Programming</div>
+    <div class="CONCOM-department">Spoken Word</div>
+    <div class="CONCOM-department">Teen Room</div>
+    <div class="CONCOM-new-department-div">
+      <button class="CONCOM-new-department-button"><i class="fas fa-plus-square"></i></button>
+    </div>
+  </div>
+</div>
+`;
+
+const StaffStructureDivision = {
+  template: TEMPLATE
+};
+
+export default StaffStructureDivision;

--- a/modules/concom/vue/components/StaffStructureSidebar.js
+++ b/modules/concom/vue/components/StaffStructureSidebar.js
@@ -1,0 +1,27 @@
+const PROPS = {
+  name: String
+};
+
+const TEMPLATE = `
+  <div class="UI-sidebar-hidden UI-fixed" :id="name">
+    <template v-if="name === 'edit_department_position'">
+      <staff-sidebar-department :edit="true"></staff-sidebar-department>
+    </template>
+    <template v-if="name === 'edit_department_email'">
+      <staff-sidebar-email :edit="true"></staff-sidebar-email>
+    </template>
+    <template v-if="name === 'edit_department_permissions'">
+      <staff-sidebar-department-permissions :edit="true"></staff-sidebar-department-permissions>
+    </template>
+    <template v-if="name === 'add_permissions'">
+      <staff-sidebar-permissions></staff-sidebar-permissions>
+    </template>
+  </div>
+`;
+
+const StaffStructureSidebar = {
+  props: PROPS,
+  template: TEMPLATE
+};
+
+export default StaffStructureSidebar;

--- a/modules/concom/vue/views/StaffStructurePage.js
+++ b/modules/concom/vue/views/StaffStructurePage.js
@@ -1,0 +1,38 @@
+const TEMPLATE = `
+  <div class="UI-container">
+    <div class="UI-maincontent">
+      <div class="CONCOM-admin-content">
+        <div class="CONCOM-admin-section">
+          <span>ConCom Structure</span>
+        </div>
+        
+        <div class="UI-maincontent">
+          <div class="UI-container UI-padding UI-center">
+            Basic Usage:
+            <p>Use the <i class="fas fa-plus-square"></i> to add a new department</p>
+            <p>Use the <span class="UI-yellow">Add New Division<i class="fas fa-plus-square"></i></span> button to add a new Division</p>
+            <p>Drag departments around to change the division</p>
+            <p>Double click on Divisions or Departments to change the properties</p>
+          </div>
+
+          <div class="UI-container UI-margin UI-center">
+            <button class="UI-redbutton UI-padding UI-margin">All ConCom Site Permissions (RBAC)</button>
+          </div>
+
+          <staff-structure-division></staff-structure-division>
+        </div>
+      </div>
+    </div>
+
+    <staff-structure-sidebar name="edit_department_position"></staff-structure-sidebar>
+    <staff-structure-sidebar name="edit_department_email"></staff-structure-sidebar>
+    <staff-structure-sidebar name="edit_department_permissions"></staff-structure-sidebar>
+    <staff-structure-sidebar name="add_permissions"></staff-structure-sidebar>
+  </div>
+`;
+
+const StaffStructurePage = {
+  template: TEMPLATE
+};
+
+export default StaffStructurePage;


### PR DESCRIPTION
This PR includes the general structure of components that are intended for use in the ConCom Structure Page.

For this initial pass, components are rendered with fully static HTML. The components are not integrated into the page with this PR and have no actions attached to any of the rendered HTML. There is a chance that I will re-work some of the sidebar components as I start to wire things together.

I chose to modify the structure of the files slightly to follow along with [guidelines presented here](https://vueschool.io/articles/vuejs-tutorials/how-to-structure-a-large-scale-vue-js-application/) based on what a Vue project would create if you started a Vue project from scratch.

I have only added components and views with this initial commit.

The intent is that for this, and future conversions to Vue we will follow this pattern, and after all of the site pages are rendered using Vue components, I will go back and convert existing implementations to follow this pattern more closely.