### PR TITLE
ConCom Structure Page

### DIFF
--- a/modules/concom/vue/StaffStructureApp.js
+++ b/modules/concom/vue/StaffStructureApp.js
@@ -1,0 +1,21 @@
+/* globals Vue */
+import StaffStructurePage from './views/StaffStructurePage.js';
+import StaffStructureDivision from './components/StaffStructureDivision.js';
+import StaffSidebarDepartment from './components/StaffSidebarDepartment.js';
+import StaffSidebarDepartmentPermissions from './components/StaffSidebarDepartmentPermissions.js';
+import StaffSidebarPermissions from './components/StaffSidebarPermissions.js';
+import StaffStructureSidebar from './components/StaffStructureSidebar.js';
+import StaffSidebarEmail from './components/StaffSidebarEmail.js';
+
+const StaffStructureApp = Vue.createApp({});
+StaffStructureApp.component('staff-structure-page', StaffStructurePage);
+StaffStructureApp.component('staff-structure-division', StaffStructureDivision);
+StaffStructureApp.component('staff-sidebar-email', StaffSidebarEmail);
+StaffStructureApp.component('staff-sidebar-department', StaffSidebarDepartment);
+StaffStructureApp.component('staff-sidebar-department-permissions', StaffSidebarDepartmentPermissions);
+StaffStructureApp.component('staff-sidebar-permissions', StaffSidebarPermissions);
+StaffStructureApp.component('staff-structure-sidebar', StaffStructureSidebar);
+
+StaffStructureApp.mount('#staff-structure-app');
+
+export default StaffStructureApp;

--- a/modules/concom/vue/components/StaffSidebarDepartment.js
+++ b/modules/concom/vue/components/StaffSidebarDepartment.js
@@ -1,0 +1,128 @@
+/* globals Vue */
+const PROPS = {
+  data: Object
+};
+
+const TEMPLATE = `
+  <div class="UI-center">
+    <h2 class="UI-red">Position Details</h2>
+  </div>
+  <div>
+    <hr/>
+    <label class="UI-label" for="position_name">Position Name:</label>
+    <input class="UI-input" id="position_name" v-model="departmentName" />
+
+    <label class="UI-label" for="department_email">Position Emails:</label>
+    <div class="UI-border" id="department_email">
+      <template v-for="email in departmentEmails">
+        <button class="UI-roundbutton">{{ email }}</button>
+        <br/>
+      </template>
+      <button class="UI-roundbutton"><i class="fas fa-plus-square"></i></button>
+    </div>
+
+    <button class="UI-redbutton UI-padding UI-margin" v-if="canEditRbac">
+      Position Site Permissions (RBAC)
+    </button><br/>
+
+    <label class="UI-label" for="department_staff_count">Staff Count:</label>
+    <input class="UI-input" id="department_staff_count" readonly :value="staffCount" />
+
+    <div>
+      <label class="UI-label" for="department_subdepartments">Sub Departments:</label>
+      <input class="UI-input" id="department_subdepartments" readonly :value="subDepartments" />
+    </div>
+
+    <div v-if="isDivisionToggle">
+      <label class="UI-label" for="department_fallback_dept">Fallback For:</label>
+      <select class="UI-select" style="width:auto" id="department_fallback_dept" v-model="selectedFallbackDepartment">
+        <option disabled value="">Please select a fallback department</option>
+        <option v-for="division in fallbackDivisions" :key="division.id" :value="division">
+          {{ division.name }}
+        </option>
+      </select>
+    </div>
+    <div v-else>
+      <label class="UI-label" for="parent_department">Division:</label>
+      <select class="UI-select" style="width:auto" id="parent_department" v-model="selectedParentDepartment">
+        <option disabled value="">Please select a parent department</option>
+        <option v-for="division in divisions" :key="division.id" :value="division">
+          {{ division.name }}
+        </option>
+      </select>
+    </div>
+  </div>
+  <div>
+    <div class="UI-table switch-table UI-padding UI-center">
+      <div class="UI-table-row">
+        <div class="UI-table-cell">
+          <span class="UI-padding">Department</span>
+          <label class="switch">
+            <input class="toggle" type="checkbox" v-model="isDivisionToggle"/>
+            <div class="slider"></div>
+          </label>
+          <span class="UI-padding">Division</span>
+        </div>
+      </div>
+    </div>
+    <div class="UI-center">
+      <hr/>
+      <button class="UI-eventbutton" @click="onSave">Save</button>
+      <button class="UI-yellowbutton" @click="$emit('sidebarClosed')">Close</button>
+      <button class="UI-redbutton" @click="onDelete" :disabled="departmentId === -1">Delete</button>
+    </div>
+  </div>
+`;
+
+function onSave() {
+  console.log('onSave clicked');
+}
+
+function onDelete() {
+  console.log('onDelete clicked');
+}
+
+function setup(props) {
+  const departmentId = Vue.ref(props.data?.id ?? -1);
+  const departmentName = Vue.ref(props.data?.departmentName ?? props.data?.isDivision ? 'New Division' : 'New Department');
+  const departmentEmails = Vue.ref(props.data?.departmentEmails ?? []);
+  const departmentPermissions = Vue.ref(props.data?.departmentPermissions ?? { 'Head': [], 'Sub-Head': [], 'Specialist': [] });
+  const staffCount = Vue.ref(props.data?.staffCount ?? 0);
+  const subDepartments = Vue.ref(props.data?.subDepartments ?? 0);
+  const selectedFallbackDepartment = Vue.ref(props.data?.fallbackDepartment ?? {});
+  const selectedParentDepartment = Vue.ref(props.data?.parentDepartment ?? {});
+  const isDivisionToggle = Vue.ref(props.data?.isDivision ?? props.isDivision);
+
+  const canEditRbac = Vue.inject('canEditRbac');
+  const divisions = Vue.inject('divisions');
+
+  const fallbackDivisions = divisions.value.filter((division) => division.id !== departmentId);
+
+  return {
+    departmentId,
+    departmentName,
+    departmentEmails,
+    departmentPermissions,
+    staffCount,
+    subDepartments,
+    selectedFallbackDepartment,
+    selectedParentDepartment,
+    isDivisionToggle,
+    canEditRbac: canEditRbac.value,
+    divisions,
+    fallbackDivisions
+  }
+}
+
+const StaffSidebarDepartment = {
+  props: PROPS,
+  emits: [ 'sidebarClosed' ],
+  setup,
+  methods: {
+    onSave,
+    onDelete
+  },
+  template: TEMPLATE
+};
+
+export default StaffSidebarDepartment;

--- a/modules/concom/vue/components/StaffSidebarDepartmentPermissions.js
+++ b/modules/concom/vue/components/StaffSidebarDepartmentPermissions.js
@@ -1,0 +1,41 @@
+const PROPS = {
+  edit: Boolean
+}
+
+const TEMPLATE = `
+  <div class="UI-center">
+    <h2 class="UI-red">Position Permissions</h2>
+  </div>
+  <div>
+    <label class="UI-label" for="updated_inherited">Inherited Permissions:</label>
+    <div id="updated_inherited" class="UI-border">
+      <span><b>Head: </b>
+        <span>site.concom.structure</span> <span>site.concom.permissions</span>
+      </span><br/>
+      <span><b>Sub-Head: </b></span><br/>
+      <span><b>Specialist: </b></span><br/>
+    </div>
+    <label class="UI-label" for="updated_present">Department Permissions:</label>
+    <div id="updated_position" class="UI-border">
+      <span><b>Head: </b>
+        <span><button class="UI-roundbutton"><i class="fas fa-plus-square"></i></button></span>
+      </span><br/>
+      <span><b>Sub-Head: </b>
+        <span><button class="UI-roundbutton"><i class="fas fa-plus-square"></i></button></span>
+      </span><br/>
+      <span><b>Specialist: </b>
+        <span><button class="UI-roundbutton"><i class="fas fa-plus-square"></i></button></span>
+      </span><br/>
+    </div>
+  </div>
+  <div class="UI-center">
+    <button class="UI-yellowbutton">Close</button>
+  </div>
+`;
+
+const StaffSidebarDepartmentPermissions = {
+  props: PROPS,
+  template: TEMPLATE
+};
+
+export default StaffSidebarDepartmentPermissions;

--- a/modules/concom/vue/components/StaffSidebarEmail.js
+++ b/modules/concom/vue/components/StaffSidebarEmail.js
@@ -1,0 +1,31 @@
+const PROPS = {
+  edit: Boolean
+}
+
+const TEMPLATE = `
+  <div class="UI-center">
+    <h2 class="UI-red">Position Email</h2>
+  </div>
+  <div>
+    <hr/>
+    <label class="UI-label" for="updated_email_email">EMail:</label>
+    <input id="updated_email_email" class="UI-input" value="test@test-con.org" />
+    <input id="updated_email_original" class="UI-hide" readonly />
+    <input id="updated_email_alias" class="UI-hide" readonly />
+    <input id="updated_email_index" class="UI-hide" readonly />
+    <input id="updated_email_dept" class="UI-hide" readonly />
+  </div>
+  <div class="UI-center">
+    <hr/>
+    <button class="UI-eventbutton">Save</button>
+    <button class="UI-yellowbutton">Close</button>
+    <button class="UI-redbutton">Delete</button>
+  </div>
+`;
+
+const StaffSidebarEmail = {
+  props: PROPS,
+  template: TEMPLATE
+};
+
+export default StaffSidebarEmail;

--- a/modules/concom/vue/components/StaffSidebarPermissions.js
+++ b/modules/concom/vue/components/StaffSidebarPermissions.js
@@ -1,0 +1,41 @@
+const TEMPLATE = `
+  <div class="UI-center">
+    <h2 class="UI-red">Add Permission</h2>
+  </div>
+  <div>
+    <hr/>
+    <select class="UI-select" style="width:auto" id="updated_perm_perm">
+      <option>admin.sudo</option>
+      <option>api.get.deadline.all</option>
+      <option>api.delete.deadline.all</option>
+      <option>api.post.deadline.all</option>
+      <option>api.put.deadline.all</option>
+      <option>asset.admin</option>
+      <option>concom.reports</option>
+      <option>concom.view</option>
+      <option>concom.modify.all</option>
+      <option>concom.add.all</option>
+      <option>registration.reports</option>
+      <option>site.admin</option>
+      <option>site.concom.permissions</option>
+      <option>site.concom.structure</option>
+      <option>site.email_lists</option>
+      <option>volunteers.admin</option>
+      <option>volunteers.reports</option>
+    </select>
+
+    <input class="UI-hide" id="updated_perm_dept" readonly />
+    <input class="UI-hide" id="updated_perm_position" readonly />
+  </div>
+  <div class="UI-center">
+    <hr/>
+    <button class="UI-eventbutton">Save</button>
+    <button class="UI-yellowbutton">Close</button>
+  </div>
+`;
+
+const StaffSidebarPermissions = {
+  template: TEMPLATE
+};
+
+export default StaffSidebarPermissions;

--- a/modules/concom/vue/components/StaffStructureDivision.js
+++ b/modules/concom/vue/components/StaffStructureDivision.js
@@ -1,0 +1,31 @@
+const PROPS = {
+  divisions: Array
+}
+
+const TEMPLATE = `
+<div class="UI-container UI-margin">
+  <button class="CONCOM-new-division-button" @click="$emit('addDivision')">
+    <span>Add New Division</span> <i class="fas fa-plus-square"></i>
+  </button>
+</div>
+
+<div class="UI-container UI-margin" v-for="division in divisions" :key="division.name">
+  <span class="CONCOM-division-span">{{ division.name }}</span>
+  <div class="CONCOM-division-drag-div">
+    <div class="CONCOM-department" v-for="department in division.departments" :key="department.name">
+      {{ department.name }}
+    </div>
+    <div class="CONCOM-new-department-div">
+      <button class="CONCOM-new-department-button" @click="$emit('addDepartment', division)"><i class="fas fa-plus-square"></i></button>
+    </div>
+  </div>
+</div>
+`;
+
+const StaffStructureDivision = {
+  props: PROPS,
+  emits: ['addDivision', 'addDepartment'],
+  template: TEMPLATE
+};
+
+export default StaffStructureDivision;

--- a/modules/concom/vue/components/StaffStructureSidebar.js
+++ b/modules/concom/vue/components/StaffStructureSidebar.js
@@ -1,0 +1,34 @@
+const PROPS = {
+  name: String,
+  data: Object
+};
+
+const TEMPLATE = `
+  <template v-if="name != null">
+    <div class="UI-sidebar-shown UI-fixed">
+      <template v-if="name === 'department'">
+        <staff-sidebar-department :data="data" @sidebar-closed="$emit('sidebarClosed')"></staff-sidebar-department>
+      </template>
+      <template v-if="name === 'department_email'">
+        <staff-sidebar-email></staff-sidebar-email>
+      </template>
+      <template v-if="name === 'department_permissions'">
+        <staff-sidebar-department-permissions></staff-sidebar-department-permissions>
+      </template>
+      <template v-if="name === 'permissions'">
+        <staff-sidebar-permissions></staff-sidebar-permissions>
+      </template>
+    </div>
+  </template>
+  <template v-else>
+
+  </template>
+`;
+
+const StaffStructureSidebar = {
+  props: PROPS,
+  emits: [ 'sidebarClosed' ],
+  template: TEMPLATE
+};
+
+export default StaffStructureSidebar;

--- a/modules/concom/vue/composables/currentUser.js
+++ b/modules/concom/vue/composables/currentUser.js
@@ -1,0 +1,34 @@
+/* globals apiRequest, Vue */
+
+export function useCurrentUser() {
+  const user = Vue.ref(null);
+  const loadingUser = Vue.ref(false);
+  const userError = Vue.ref(null);
+
+  async function fetchUser() {
+    loadingUser.value = true;
+
+    try {
+      const userResponse = await apiRequest('GET', 'member');
+      const userData = JSON.parse(userResponse.responseText);
+
+      const userPermissionsResponse = await apiRequest('GET', `member/${userData.id}/permissions?max_results=all`);
+      const userPermissionData = JSON.parse(userPermissionsResponse.responseText);
+
+      user.value = {
+        id: parseInt(userData.id),
+        permissions: userPermissionData.data
+      };
+    } catch (error) {
+      userError.value = error.message;
+    } finally {
+      loadingUser.value = false;
+    }
+  }
+
+  function hasPermission(permission) {
+    return user.value?.permissions?.find((item) => item.subtype === permission)?.allowed === 1;
+  }
+
+  return { user, loadingUser, userError, fetchUser, hasPermission };
+}

--- a/modules/concom/vue/composables/divisionHierarchy.js
+++ b/modules/concom/vue/composables/divisionHierarchy.js
@@ -1,0 +1,25 @@
+/* globals apiRequest, Vue */
+import { extractDivisionHierarchy } from '../../sitesupport/division-parser.js';
+
+export function useDivisionHierarchy() {
+  const divisions = Vue.ref(null);
+  const loadingDivisions = Vue.ref(false);
+  const divisionsError = Vue.ref(null);
+
+  async function fetchDivisions() {
+    loadingDivisions.value = true;
+
+    try {
+      const divisionsResponse = await apiRequest('GET', 'department');
+      const divisionData = JSON.parse(divisionsResponse.responseText);
+
+      divisions.value = extractDivisionHierarchy(divisionData.data);
+    } catch (error) {
+      divisionsError.value = error.message;
+    } finally {
+      loadingDivisions.value = false;
+    }
+  }
+
+  return { divisions, loadingDivisions, divisionsError, fetchDivisions };
+}

--- a/modules/concom/vue/views/StaffStructurePage.js
+++ b/modules/concom/vue/views/StaffStructurePage.js
@@ -1,0 +1,106 @@
+/* globals Vue, showSpinner, hideSpinner */
+import { useCurrentUser } from '../composables/currentUser.js';
+import { useDivisionHierarchy } from '../composables/divisionHierarchy.js';
+
+const TEMPLATE = `
+  <div class="UI-container">
+    <div :class="sidebarDisplayClass">
+      <div class="CONCOM-admin-content">
+        <div class="CONCOM-admin-section">
+          <span>ConCom Structure</span>
+        </div>
+        
+        <div class="UI-maincontent">
+          <div class="UI-container UI-padding UI-center">
+            Basic Usage:
+            <p>Use the <i class="fas fa-plus-square"></i> to add a new department</p>
+            <p>Use the <span class="UI-yellow">Add New Division<i class="fas fa-plus-square"></i></span> button to add a new Division</p>
+            <p>Drag departments around to change the division</p>
+            <p>Double click on Divisions or Departments to change the properties</p>
+          </div>
+
+          <template v-if="canEditRbac">
+            <div class="UI-container UI-margin UI-center">
+              <button class="UI-redbutton UI-padding UI-margin">All ConCom Site Permissions (RBAC)</button>
+            </div>
+          </template>
+          
+          <staff-structure-division :divisions="divisions" @add-division="addDepartmentClicked" 
+            @add-department="addDepartmentClicked"></staff-structure-division>
+        </div>
+      </div>
+    </div>
+
+    <staff-structure-sidebar :name="sidebarName" :data="sidebarData" 
+      @sidebar-closed="closeSidebarClicked"></staff-structure-sidebar>
+  </div>
+`;
+
+function setup() {
+  const { user, loadingUser, fetchUser, hasPermission } = useCurrentUser();
+  const { divisions, loadingDivisions, fetchDivisions } = useDivisionHierarchy();
+  const canEditRbac = Vue.ref(false);
+  const showSidebar = Vue.ref(false);
+  const sidebarName = Vue.ref(null);
+  const sidebarData = Vue.ref(null);
+
+  const loadingValues = [loadingUser, loadingDivisions];
+  const sidebarDisplayClass = Vue.computed(() => showSidebar.value ? 'UI-maincontent UI-mainsection-sidebar-shown' : 'UI-maincontent')
+
+  Vue.watch([loadingUser, loadingDivisions], () => {
+    loadingValues.some((item) => item.value) ? showSpinner() : hideSpinner();
+  });
+
+  Vue.watch(user, () => {
+    canEditRbac.value = hasPermission('site.concom.permissions');
+  });
+
+  Vue.provide('canEditRbac', canEditRbac);
+  Vue.provide('divisions', divisions);
+
+  return {
+    fetchUser,
+    fetchDivisions,
+    divisions,
+    canEditRbac,
+    showSidebar,
+    sidebarName,
+    sidebarData,
+    sidebarDisplayClass
+  }
+}
+
+async function onCreated() {
+  await Promise.all([
+    this.fetchUser(),
+    this.fetchDivisions()
+  ]);
+}
+
+function addDepartmentClicked(division) {
+  if (division == null) {
+    this.sidebarData = { isDivision: true };
+  } else {
+    this.sidebarData = { isDivision: false };
+  }
+
+  this.sidebarName = 'department';
+  this.showSidebar = !this.showSidebar;
+}
+
+function closeSidebarClicked() {
+  this.showSidebar = false;
+  this.sidebarName = null;
+}
+
+const StaffStructurePage = {
+  setup,
+  created: onCreated,
+  methods: {
+    addDepartmentClicked,
+    closeSidebarClicked
+  },
+  template: TEMPLATE
+};
+
+export default StaffStructurePage;


### PR DESCRIPTION
This PR includes a few distinct commits which I can squash as needed.

Initial components for rendering the page with Vue components along with a couple of hooked up "composable" pieces for user permissions to support rendering, and divisions.

Also includes the loosely wired up department sidebar that simply logs when buttons on the sidebar are clicked.

This is still not hooked up on the main page yet, but if you make a couple of changes locally you can see it working.

- In `concom/admin/pages/body.inc`, add the following block starting at the first line:
```
<div id="staff-structure-app">
    <staff-structure-page></staff-structure-page>
</div>
```

- In `concom/admin/pages/head.inc` add `<script src="modules/concom/vue/StaffStructureApp.js" type="module"></script>`

No tests yet, but I can work to add those after finishing out the behavior on the sidebar. Next PR will include API changes to support saving and deleting a department/division.