### PR TITLE
Implement POST Department API Endpoint

### DIFF
--- a/api/src/App/Routes.php
+++ b/api/src/App/Routes.php
@@ -34,6 +34,7 @@ function setupAPIRoutes(App $app, $authMiddleware)
         '/department',
         function () use ($app, $authMiddleware) {
             $app->get('[/]', 'App\Controller\Department\ListDepartments');
+            $app->post('[/]', 'App\Controller\Department\PostDepartment');
             $app->get('/{name}', 'App\Controller\Department\GetDepartment');
             $app->get('/{name}/children', 'App\Controller\Department\GetDepartmentChildren');
             $app->get('/{name}/deadlines', 'App\Controller\Deadline\ListDepartmentDeadlines');

--- a/api/src/Controller/Department/PostDepartment.php
+++ b/api/src/Controller/Department/PostDepartment.php
@@ -1,0 +1,107 @@
+<?php declare(strict_types=1);
+
+/**
+ * @OA\Post(
+ *     tags={"departments"},
+ *     path="/department",
+ *     summary="Create new department",
+ *     @OA\RequestBody(
+ *         @OA\MediaType(
+ *             mediaType="multipart/form-data",
+ *             @OA\Schema(
+ *                 @OA\Property(
+ *                     property="Name",
+ *                     description="The name for the new department",
+ *                     nullable=false,
+ *                     type="string"
+ *                 ),
+ *                 @OA\Property(
+ *                     property="ParentID",
+ *                     description="The ID for the parent department",
+ *                     nullable=true,
+ *                     type="integer"
+ *                 ),
+ *                 @OA\Property(
+ *                     property="FallbackID",
+ *                     description="The ID for the fallback department",
+ *                     nullable=true,
+ *                     type="integer"
+ *                 )
+ *             )
+ *         )
+ *     ),
+ *     @OA\Response(
+ *         response=201,
+ *         description="Created",
+ *         ref="#/components/schemas/department"
+ *     ),
+ *     @OA\Response(
+ *         response=401,
+ *         ref="#/components/responses/401"
+ *     ),
+ *     @OA\Response(
+ *         response=400,
+ *         ref="#/components/responses/400"
+ *     ),
+ *     security={{"ciab_auth":{}}}
+ * )
+ */
+
+namespace App\Controller\Department;
+
+use App\Error\InvalidParameterException;
+use Slim\Container;
+use Slim\Http\Request;
+use Slim\Http\Response;
+
+use App\Service\DepartmentService;
+
+class PostDepartment extends BaseDepartment
+{
+
+    /**
+     * @var DepartmentService
+     */
+    protected $departmentService;
+
+
+    public function __construct(Container $container)
+    {
+        parent::__construct($container);
+        $this->departmentService = $container->get("DepartmentService");
+        $this->includes = null;
+
+    }
+
+
+    public function buildResource(Request $request, Response $response, $params): array
+    {
+        // Need to figure out which permission is appropriate here.
+        // $permissions = ['site.concom.permissions'];
+        // $this->checkPermissions($permissions);
+
+        $required = ['Name'];
+        $body = $this->checkRequiredBody($request, $required);
+
+        if (array_key_exists("ParentID", $body) && $body["ParentID"] <= 0) {
+            throw new InvalidParameterException("ParentID must be greater than 0");
+        }
+
+        if (array_key_exists("FallbackID", $body) && $body["FallbackID"] <= 0) {
+            throw new InvalidParameterException("FallbackID must be greater than 0");
+        }
+
+        $createdDept = $this->departmentService->post($body);
+        $result = $this->departmentService->getById($createdDept)[$createdDept];
+
+        return [
+          \App\Controller\BaseController::RESOURCE_TYPE,
+          $result,
+          201
+        ];
+
+    }
+
+
+  /* End PostDepartment */
+}

--- a/api/src/Modules/staff/Repository/StaffRepository.php
+++ b/api/src/Modules/staff/Repository/StaffRepository.php
@@ -46,7 +46,7 @@ class StaffRepository implements RepositoryInterface
     }
 
 
-    public function insert(/*.mixed.*/$data): void
+    public function insert(/*.mixed.*/$data): int
     {
         throw new Exception(__CLASS__.": Method '__FUNCTION__' not implemented");
 

--- a/api/src/Modules/staff/Service/StaffService.php
+++ b/api/src/Modules/staff/Service/StaffService.php
@@ -84,7 +84,7 @@ class StaffService implements ServiceInterface
     }
 
 
-    public function post(/*.mixed.*/$data): void
+    public function post(/*.mixed.*/$data): int
     {
         throw new Exception(__CLASS__.": Method '__FUNCTION__' not implemented");
 

--- a/api/src/Repository/EventRepository.php
+++ b/api/src/Repository/EventRepository.php
@@ -59,7 +59,7 @@ class EventRepository implements RepositoryInterface
     }
 
 
-    public function insert(/*.mixed.*/$data): void
+    public function insert(/*.mixed.*/$data): int
     {
         throw new Exception(__CLASS__.": Method '__FUNCTION__' not implemented");
 

--- a/api/src/Repository/MemberRepository.php
+++ b/api/src/Repository/MemberRepository.php
@@ -66,7 +66,7 @@ class MemberRepository implements RepositoryInterface
     }
 
 
-    public function insert(/*.mixed.*/$data): void
+    public function insert(/*.mixed.*/$data): int
     {
         throw new Exception(__CLASS__.": Method '__FUNCTION__' not implemented");
 

--- a/api/src/Repository/RepositoryInterface.php
+++ b/api/src/Repository/RepositoryInterface.php
@@ -9,7 +9,7 @@ interface RepositoryInterface
 {
 
 
-    public function insert(/*.mixed.*/$data): void;
+    public function insert(/*.mixed.*/$data): int;
 
 
     public function selectAll(): array;

--- a/api/src/Service/DepartmentService.php
+++ b/api/src/Service/DepartmentService.php
@@ -50,10 +50,10 @@ class DepartmentService implements ServiceInterface
     }
 
 
-    public function post(/*.mixed.*/$data): void
+    public function post(/*.mixed.*/$data): int
     {
-        throw new Exception(__CLASS__.": Method '__FUNCTION__' not implemented");
-
+        return $this->departmentRepository->insert($data);
+        
     }
 
 

--- a/api/src/Service/EventService.php
+++ b/api/src/Service/EventService.php
@@ -59,7 +59,7 @@ class EventService implements ServiceInterface
     }
 
 
-    public function post(/*.mixed.*/$data): void
+    public function post(/*.mixed.*/$data): int
     {
         throw new Exception(__CLASS__.": Method '__FUNCTION__' not implemented");
 

--- a/api/src/Service/MemberService.php
+++ b/api/src/Service/MemberService.php
@@ -69,7 +69,7 @@ class MemberService implements ServiceInterface
     }
 
 
-    public function post(/*.mixed.*/$data): void
+    public function post(/*.mixed.*/$data): int
     {
         throw new Exception(__CLASS__.": Method '__FUNCTION__' not implemented");
 

--- a/api/src/Service/ServiceInterface.php
+++ b/api/src/Service/ServiceInterface.php
@@ -9,7 +9,7 @@ interface ServiceInterface
 {
 
 
-    public function post(/*.mixed.*/$data): void;
+    public function post(/*.mixed.*/$data): int;
 
 
     public function listAll(): array;

--- a/api/src/Tests/Cases/DepartmentTest.php
+++ b/api/src/Tests/Cases/DepartmentTest.php
@@ -8,30 +8,186 @@ class DepartmentTest extends CiabTestCase
 {
 
 
-    public function testDepartment(): void
+    public function testGetDepartmentList(): void
     {
-        $data = $this->runSuccessJsonRequest('GET', '/department');
+        $data = $this->runSuccessJsonRequest('GET', '/department', null, null, 200, null);
         $this->assertNotEmpty($data->data);
-        $data = $this->runSuccessJsonRequest('GET', '/department/Activities');
-        $data2 = $this->runSuccessJsonRequest('GET', '/department/2');
-        $this->assertEquals($data, $data2);
-        $this->runSuccessJsonRequest('GET', '/department/2/children');
-        $this->runSuccessJsonRequest('GET', '/department');
-        $data = $this->runSuccessJsonRequest(
-            'GET',
-            '/department/100'
-        );
-        $this->assertIsObject($data->parent);
-        $this->assertIncludes($data, 'parent');
 
     }
 
 
-    public function testDepartmentErrors(): void
+    public function testGetDepartmentByName(): void
     {
-        $this->runRequest('GET', '/department/-1', null, null, 404);
-        $this->runRequest('GET', '/department/not-a-dept', null, null, 404);
+        $data = $this->runSuccessJsonRequest('GET', '/department/Activities', null, null, 200, null, '/department/{id}');
+        $this->assertEquals("Activities", $data->name);
 
+    }
+
+
+    public function testGetDepartmentById(): void
+    {
+        $data = $this->runSuccessJsonRequest('GET', '/department/2', null, null, 200, null, '/department/{id}');
+        $this->assertEquals("2", $data->id);
+
+    }
+
+
+    public function testGetDepartmentByIdOrName(): void
+    {
+        $dataByName = $this->runSuccessJsonRequest('GET', '/department/Activities');
+        $dataById = $this->runSuccessJsonRequest('GET', '/department/2');
+        $this->assertEquals($dataByName, $dataById);
+
+    }
+
+    
+    public function testGetDepartmentChildren(): void
+    {
+        $data = $this->runSuccessJsonRequest('GET', '/department/2/children', null, null, 200, null, '/department/{id}/children');
+        $this->assertNotEmpty($data->data);
+
+    }
+
+
+    public function testGetDepartmentWithParent(): void
+    {
+        $data = $this->runSuccessJsonRequest('GET', '/department/100');
+        $this->assertEquals('100', $data->id);
+        $this->assertIncludes($data, 'parent');
+        $this->assertIsObject($data->parent);
+
+    }
+
+
+    public function testPostDepartment(): void
+    {
+        $body = [
+            "Name" => "Test Department"
+        ];
+
+        $data = $this->runSuccessJsonRequest('POST', '/department', null, $body, 201, null, '/department');
+        $this->assertEquals('Test Department', $data->name);
+        $this->assertNotEmpty($data->id);
+        $this->assertEmpty($data->parent);
+        $this->assertEmpty($data->fallback);
+
+    }
+
+    
+    public function testPostDepartmentWithParent(): void
+    {
+        $parentDept = [
+            "Name" => "Test Parent Department"
+        ];
+
+        $parentData = $this->runSuccessJsonRequest('POST', '/department', null, $parentDept, 201, null);
+
+        $withParentRef = [
+            "Name" => "Test Department with Parent",
+            "ParentID" => $parentData->id
+        ];
+
+        $withParentData = $this->runSuccessJsonRequest('POST', '/department', null, $withParentRef, 201, null, '/department');
+        $this->assertEquals('Test Department with Parent', $withParentData->name);
+        $this->assertNotEmpty($withParentData->id);
+        $this->assertEmpty($withParentData->fallback);
+        $this->assertEquals($parentData->id, $withParentData->parent->id);
+
+    }
+
+
+    public function testPostDepartmentWithFallback(): void
+    {
+        $fallbackDept = [
+            "Name" => "Test Fallback Department"
+        ];
+
+        $fallbackData = $this->runSuccessJsonRequest('POST', '/department', null, $fallbackDept, 201, null);
+
+        $withFallbackRef = [
+            "Name" => "Test Department with Fallback",
+            "FallbackID" => $fallbackData->id
+        ];
+
+        $withFallbackData = $this->runSuccessJsonRequest('POST', '/department', null, $withFallbackRef, 201, null, '/department');
+        $this->assertEquals('Test Department with Fallback', $withFallbackData->name);
+        $this->assertNotEmpty($withFallbackData->id);
+        $this->assertEmpty($withFallbackData->parent);
+        $this->assertEquals($fallbackData->id, $withFallbackData->fallback->id);
+
+    }
+
+
+    public function testPostDepartmentWithParentAndFallback(): void
+    {
+        $parentDept = [
+            "Name" => "Test Parent Department"
+        ];
+
+        $parentData = $this->runSuccessJsonRequest('POST', '/department', null, $parentDept, 201, null);
+
+        $fallbackDept = [
+            "Name" => "Test Fallback Department"
+        ];
+
+        $fallbackData = $this->runSuccessJsonRequest('POST', '/department', null, $fallbackDept, 201, null);
+
+        $withParentAndFallbackRef = [
+            "Name" => "Test Department with Parent and Fallback",
+            "ParentID" => $parentData->id,
+            "FallbackID" => $fallbackData->id
+        ];
+
+        $withParentFallbackData = $this->runSuccessJsonRequest('POST', '/department', null, $withParentAndFallbackRef, 201, null);
+        $this->assertEquals('Test Department with Parent and Fallback', $withParentFallbackData->name);
+        $this->assertNotEmpty($withParentFallbackData->id);
+        $this->assertEquals($parentData->id, $withParentFallbackData->parent->id);
+        $this->assertEquals($fallbackData->id, $withParentFallbackData->fallback->id);
+        
+    }
+
+
+    public function testGetDepartmentInvalidId(): void
+    {
+        $this->runRequest('GET', '/department/-1', null, null, 404, null, '/department/{id}');
+
+    }
+
+
+    public function testGetDepartmentInvalidName(): void
+    {
+        $this->runRequest('GET', '/department/not-real-department', null, null, 404, null, '/department/{id}');
+
+    }
+
+    
+    public function testPostDepartmentMissingName(): void
+    {
+        $body = [];
+        $this->runRequest('POST', '/department', null, $body, 400, null, null, '/department');
+
+    }
+
+
+    public function testPostDepartmentInvalidParentId(): void
+    {
+        $body = [
+            "Name" => "Test Department",
+            "ParentID" => -1
+        ];
+        $this->runRequest('POST', '/department', null, $body, 400, null, null, '/department');
+
+    }
+
+    
+    public function testPostDepartmentInvalidFallbackId(): void
+    {
+        $body = [
+            "Name" => "Test Department",
+            "FallbackID" => -1
+        ];
+        $this->runRequest('POST', '/department', null, $body, 400, null, null, '/department');
+        
     }
 
 

--- a/api/src/Tests/Cases/Service/DepartmentServiceTest.php
+++ b/api/src/Tests/Cases/Service/DepartmentServiceTest.php
@@ -1,14 +1,20 @@
 <?php declare(strict_types=1);
 
+namespace App\Tests\TestCase\Service;
+
 use App\Repository\DepartmentRepository;
 use App\Service\DepartmentService;
 use PHPUnit\Framework\TestCase;
+use Exception;
 
 final class DepartmentServiceTest extends TestCase
 {
 
     private $deptRepositoryStub;
 
+    /**
+     * @var DepartmentService
+     */
     private $systemUnderTest;
 
 
@@ -127,8 +133,16 @@ final class DepartmentServiceTest extends TestCase
 
     public function testPost()
     {
-        $this->expectException(Exception::class);
-        $this->systemUnderTest->post([]);
+        $deptId = 123;
+        $this->deptRepositoryStub->method('insert')
+            ->willReturn($deptId);
+
+        $testData = [
+          "Name" => "Test Name"
+        ];
+        
+        $result = $this->systemUnderTest->post($testData);
+        $this->assertEquals($deptId, $result);
 
     }
 

--- a/ciab.openapi.yaml
+++ b/ciab.openapi.yaml
@@ -701,6 +701,38 @@ paths:
       security:
         -
           ciab_auth: []
+    post:
+      tags:
+        - departments
+      summary: 'Create new department'
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              properties:
+                Name:
+                  nullable: false
+                  description: 'The name for the new department'
+                  type: string
+                ParentID:
+                  nullable: true
+                  description: 'The ID for the parent department'
+                  type: integer
+                FallbackID:
+                  nullable: true
+                  description: 'The ID for the fallback department'
+                  type: integer
+              type: object
+      responses:
+        '201':
+          $ref: '#/components/schemas/department'
+        '401':
+          $ref: '#/components/responses/401'
+        '400':
+          $ref: '#/components/responses/400'
+      security:
+        -
+          ciab_auth: []
   '/event/{id}':
     get:
       tags:


### PR DESCRIPTION
This PR adds an endpoint to create Departments.

* Changes function return signatures in Repository and Service Interfaces
  * I went with `array` but I think ideally the `insert` and `post` function should simply return an ID, so maybe `int` is appropriate here?
* Updates test case in the Department Service
* Re-organize and add tests for API endpoint
* Fixes an issue with memory leaks in the tests
  * Not sure how long tests were taking previously, however without this in place I couldn't even successfully run the tests. They were taking a little over a minute for me after the changes.
* Fixes a couple of lint issues that were present in the code

Need to determine the appropriate permission for the new endpoint. Previously there was no permission applied at all. In existing ConCom code, it was implied that if you had `site.concom.permissions` you would be able to create new departments without further checks. The new convention is `api.[action].[resource]` in most places, but it is not clear to me who would have the `site.concom.permissions` to appropriately grant this to users, so I chose to not add anything for now. 

Perhaps `site.concom.permissions` would be most appropriate to start?