### PR TITLE
Fix an issue with memory leaking between tests

### DIFF
--- a/api/src/Tests/Base/CiabTestCase.php
+++ b/api/src/Tests/Base/CiabTestCase.php
@@ -216,6 +216,11 @@ abstract class CiabTestCase extends TestCase
                 ->whereEquals(['AccountID' => $account])
                 ->perform();
         }
+
+        $this->middleware = null;
+        $this->container = null;
+        $this->app = null;
+
         parent::tearDown();
 
     }


### PR DESCRIPTION
This PR addresses a memory leak issue we are seeing with tests.

Originally when implementing this against the branch I had been working on for the Department API changes, I was not able to run the tests at all as they would fail after the container started going above 130 MB memory usage. I made no changes to the configuration that would have limited it to this, so I assume it must be a default or something. 

After pulling the latest from `main` I was able to run the tests without these changes, however it was clear that it was leaking memory despite finishing successfully.

Test output before change:
> Time: 39.8 seconds, Memory: 104.00 MB
> 
> OK (102 tests, 2740 assertions)

Test output after change:
> Time: 39.26 seconds, Memory: 32.00 MB
>
> OK (102 tests, 2740 assertions)

No change to test speed, but significant improvement on memory usage. There may be more that we can do, but I feel like we covered the most important factors here, which are the container, the app, and the middleware.