### PR TITLE
Add endpoint to delete departments

### DIFF
--- a/api/src/App/Dependencies.php
+++ b/api/src/App/Dependencies.php
@@ -7,9 +7,11 @@ use Psr\Container\ContainerInterface;
 use App\Handler\ApiError;
 use App\Handler\RBAC;
 use App\Repository\DepartmentRepository;
+use App\Repository\EmailRepository;
 use App\Repository\EventRepository;
 use App\Repository\MemberRepository;
 use App\Service\DepartmentService;
+use App\Service\EmailService;
 use App\Service\EventService;
 use App\Service\MemberService;
 use Slim\App;
@@ -39,6 +41,12 @@ function setupAPIDependencies(App $app, array $settings)
 
     $container['RBAC'] = function (): RBAC {
         return new RBAC;
+    };
+
+    $container['EmailService'] = function ($c): EmailService {
+        return new EmailService(
+            new EmailRepository($c['db'])
+        );
     };
 
     $container['DepartmentService'] = function ($c): DepartmentService {

--- a/api/src/App/Dependencies.php
+++ b/api/src/App/Dependencies.php
@@ -59,6 +59,8 @@ function setupAPIDependencies(App $app, array $settings)
 
     $container['DepartmentService'] = function ($c): DepartmentService {
         return new DepartmentService(
+            $c->get('EmailService'),
+            $c->get('EmailListAccessService'),
             new DepartmentRepository($c['db'])
         );
     };

--- a/api/src/App/Dependencies.php
+++ b/api/src/App/Dependencies.php
@@ -7,10 +7,12 @@ use Psr\Container\ContainerInterface;
 use App\Handler\ApiError;
 use App\Handler\RBAC;
 use App\Repository\DepartmentRepository;
+use App\Repository\EmailListAccessRepository;
 use App\Repository\EmailRepository;
 use App\Repository\EventRepository;
 use App\Repository\MemberRepository;
 use App\Service\DepartmentService;
+use App\Service\EmailListAccessService;
 use App\Service\EmailService;
 use App\Service\EventService;
 use App\Service\MemberService;
@@ -46,6 +48,12 @@ function setupAPIDependencies(App $app, array $settings)
     $container['EmailService'] = function ($c): EmailService {
         return new EmailService(
             new EmailRepository($c['db'])
+        );
+    };
+
+    $container['EmailListAccessService'] = function ($c): EmailListAccessService {
+        return new EmailListAccessService(
+            new EmailListAccessRepository($c['db'])
         );
     };
 

--- a/api/src/App/Routes.php
+++ b/api/src/App/Routes.php
@@ -36,6 +36,7 @@ function setupAPIRoutes(App $app, $authMiddleware)
             $app->get('[/]', 'App\Controller\Department\ListDepartments');
             $app->post('[/]', 'App\Controller\Department\PostDepartment');
             $app->put('/{id}', 'App\Controller\Department\PutDepartment');
+            $app->delete('/{id}', 'App\Controller\Department\DeleteDepartment');
             $app->get('/{name}', 'App\Controller\Department\GetDepartment');
             $app->get('/{name}/children', 'App\Controller\Department\GetDepartmentChildren');
             $app->get('/{name}/deadlines', 'App\Controller\Deadline\ListDepartmentDeadlines');

--- a/api/src/Controller/Department/DeleteDepartment.php
+++ b/api/src/Controller/Department/DeleteDepartment.php
@@ -1,0 +1,77 @@
+<?php declare(strict_types=1);
+
+/**
+ * @OA\Delete(
+ *     tags={"departments"},
+ *     path="/department/{id}",
+ *     summary="Delete an existing department",
+ *     @OA\Parameter(
+ *         description="ID of the department being deleted",
+ *         in="path",
+ *         name="id",
+ *         required=true,
+ *         @OA\Schema(type="integer")
+ *     ),
+ *     @OA\Response(
+ *         response=204,
+ *         description="OK"
+ *     ),
+ *     @OA\Response(
+ *         response=401,
+ *         ref="#/components/responses/401"
+ *     ),
+ *     @OA\Response(
+ *         response=400,
+ *         ref="#/components/responses/400"
+ *     ),
+ *     security={{"ciab_auth":{}}}
+ * )
+ */
+
+namespace App\Controller\Department;
+
+use App\Error\InvalidParameterException;
+use Slim\Container;
+use Slim\Http\Request;
+use Slim\Http\Response;
+
+use App\Service\DepartmentService;
+
+class DeleteDepartment extends BaseDepartment
+{
+
+    /**
+     * @var DepartmentService
+     */
+    protected $departmentService;
+
+
+    public function __construct(Container $container)
+    {
+        parent::__construct($container);
+        $this->departmentService = $container->get("DepartmentService");
+        $this->includes = null;
+
+    }
+
+
+    public function buildResource(Request $request, Response $response, $params): array
+    {
+        $departmentId = $params["id"];
+        if ($departmentId <= 0) {
+            throw new InvalidParameterException("DepartmentID must be greater than 0");
+        }
+
+        $this->departmentService->deleteById($departmentId);
+
+        return [
+            \App\Controller\BaseController::RESULT_TYPE,
+            [null],
+            204
+        ];
+
+    }
+
+
+    /* End DeleteDepartment */
+}

--- a/api/src/Repository/DepartmentRepository.php
+++ b/api/src/Repository/DepartmentRepository.php
@@ -2,7 +2,6 @@
 
 namespace App\Repository;
 
-use Exception;
 use Atlas\Query\Select;
 use Atlas\Query\Insert;
 use Atlas\Query\Update;
@@ -116,7 +115,24 @@ class DepartmentRepository implements RepositoryInterface
 
     public function deleteById(/*.mixed.*/$id): void
     {
-        throw new Exception(__CLASS__.": Method '__FUNCTION__' not implemented");
+        $placeholderDeptId = Select::new($this->db)
+            ->columns("DepartmentID")
+            ->from("Departments")
+            ->where("Name = 'Historical Placeholder'")
+            ->fetchOne();
+        
+        $update = Update::new($this->db);
+        $update->table("Departments")
+            ->column("FallbackID", null)
+            ->column("ParentDepartmentID", $placeholderDeptId["DepartmentID"])
+            ->whereEquals(["DepartmentID" => $id])
+            ->perform();
+
+        $update = Update::new($this->db);
+        $update->table("Departments")
+            ->column("FallbackID", null)
+            ->whereEquals(["FallbackID" => $id])
+            ->perform();
 
     }
 

--- a/api/src/Repository/EmailListAccessRepository.php
+++ b/api/src/Repository/EmailListAccessRepository.php
@@ -1,0 +1,67 @@
+<?php declare(strict_types=1);
+
+namespace App\Repository;
+
+use Exception;
+use Atlas\Query\Delete;
+
+class EmailListAccessRepository implements RepositoryInterface
+{
+
+    protected $db;
+
+
+    public function __construct($db)
+    {
+        $this->db = $db;
+
+    }
+
+
+    public function insert(/*.mixed.*/$data): int
+    {
+        throw new Exception(__CLASS__." Method '__FUNCTION__' not implemented");
+
+    }
+
+    
+    public function selectById(/*.mixed.*/$id): array
+    {
+        throw new Exception(__CLASS__." Method '__FUNCTION__' not implemented");
+          
+    }
+
+
+    public function selectAll(): array
+    {
+        throw new Exception(__CLASS__." Method '__FUNCTION__' not implemented");
+          
+    }
+
+
+    public function update(/*.string.*/$id, /*.mixed.*/$data): void
+    {
+        throw new Exception(__CLASS__." Method '__FUNCTION__' not implemented");
+          
+    }
+
+
+    public function deleteById(/*.mixed.*/$id): void
+    {
+        throw new Exception(__CLASS__." Method '__FUNCTION__' not implemented");
+          
+    }
+
+
+    public function deleteByDepartmentId(/*.mixed.*/$departmentId): void
+    {
+        $delete = Delete::new($this->db);
+        $delete->from("EmailListAccess")
+            ->whereEquals(["DepartmentID" => $departmentId])
+            ->perform();
+
+    }
+
+
+  /* End EmailListAccessRepository */
+}

--- a/api/src/Repository/EmailRepository.php
+++ b/api/src/Repository/EmailRepository.php
@@ -1,0 +1,67 @@
+<?php declare(strict_types=1);
+
+namespace App\Repository;
+
+use Exception;
+use Atlas\Query\Delete;
+
+class EmailRepository implements RepositoryInterface
+{
+
+    protected $db;
+
+
+    public function __construct($db)
+    {
+        $this->db = $db;
+
+    }
+
+
+    public function insert(/*.mixed.*/$data): int
+    {
+        throw new Exception(__CLASS__." Method '__FUNCTION__' not implemented");
+
+    }
+
+    
+    public function selectById(/*.mixed.*/$id): array
+    {
+        throw new Exception(__CLASS__." Method '__FUNCTION__' not implemented");
+          
+    }
+
+
+    public function selectAll(): array
+    {
+        throw new Exception(__CLASS__." Method '__FUNCTION__' not implemented");
+          
+    }
+
+
+    public function update(/*.string.*/$id, /*.mixed.*/$data): void
+    {
+        throw new Exception(__CLASS__." Method '__FUNCTION__' not implemented");
+          
+    }
+
+
+    public function deleteById(/*.mixed.*/$id): void
+    {
+        throw new Exception(__CLASS__." Method '__FUNCTION__' not implemented");
+          
+    }
+
+
+    public function deleteByDepartmentId(/*.mixed.*/$departmentId): void
+    {
+        $delete = Delete::new($this->db);
+        $delete->from("EMails")
+            ->whereEquals(["DepartmentID" => $departmentId])
+            ->perform();
+
+    }
+
+
+    /* End EmailRepository */
+}

--- a/api/src/Service/DepartmentService.php
+++ b/api/src/Service/DepartmentService.php
@@ -2,20 +2,33 @@
 
 namespace App\Service;
 
-use Exception;
+use App\Service\EmailService;
+use App\Service\EmailListAccessService;
 use App\Repository\DepartmentRepository;
 
 class DepartmentService implements ServiceInterface
 {
 
-  /**
-   * @var DepartmentRepository
-   */
+    /**
+     * @var EmailService
+     */
+    protected $emailService;
+
+    /**
+     * @var EmailListAccessService
+     */
+    protected $emailListAccessService;
+
+    /**
+     * @var DepartmentRepository
+     */
     protected $departmentRepository;
 
 
-    public function __construct(DepartmentRepository $departmentRepository)
+    public function __construct(EmailService $emailService, EmailListAccessService $emailListAccessService, DepartmentRepository $departmentRepository)
     {
+        $this->emailService = $emailService;
+        $this->emailListAccessService = $emailListAccessService;
         $this->departmentRepository = $departmentRepository;
 
     }
@@ -66,7 +79,9 @@ class DepartmentService implements ServiceInterface
 
     public function deleteById(/*.mixed.*/$id): void
     {
-        throw new Exception(__CLASS__.": Method '__FUNCTION__' not implemented");
+        $this->emailService->deleteByDepartmentId($id);
+        $this->emailListAccessService->deleteByDepartmentId($id);
+        $this->departmentRepository->deleteById($id);
 
     }
 

--- a/api/src/Service/EmailListAccessService.php
+++ b/api/src/Service/EmailListAccessService.php
@@ -1,0 +1,67 @@
+<?php declare(strict_types=1);
+
+namespace App\Service;
+
+use Exception;
+use App\Repository\EmailListAccessRepository;
+
+class EmailListAccessService implements ServiceInterface
+{
+
+    /**
+     * @var EmailListAccessRepository
+     */
+    protected $emailListAccessRepository;
+
+
+    public function __construct(EmailListAccessRepository $emailListAccessRepository)
+    {
+        $this->emailListAccessRepository = $emailListAccessRepository;
+
+    }
+
+
+    public function post(/*.mixed.*/$data): int
+    {
+        throw new Exception(__CLASS__." Method '__FUNCTION__' not implemented");
+
+    }
+
+
+    public function listAll(): array
+    {
+        throw new Exception(__CLASS__." Method '__FUNCTION__' not implemented");
+
+    }
+
+
+    public function getById(/*.mixed.*/$id): array
+    {
+        throw new Exception(__CLASS__." Method '__FUNCTION__' not implemented");
+
+    }
+
+    
+    public function put(/*.string.*/$id, /*.mixed.*/$data): void
+    {
+        throw new Exception(__CLASS__." Method '__FUNCTION__' not implemented");
+
+    }
+
+
+    public function deleteById(/*.mixed.*/$id): void
+    {
+        throw new Exception(__CLASS__." Method '__FUNCTION__' not implemented");
+
+    }
+
+
+    public function deleteByDepartmentId(/*.mixed.*/$departmentId): void
+    {
+        $this->emailListAccessRepository->deleteByDepartmentId($departmentId);
+
+    }
+
+    
+    /* End EmailListAccessService */
+}

--- a/api/src/Service/EmailService.php
+++ b/api/src/Service/EmailService.php
@@ -1,0 +1,67 @@
+<?php declare(strict_types=1);
+
+namespace App\Service;
+
+use Exception;
+use App\Repository\EmailRepository;
+
+class EmailService implements ServiceInterface
+{
+
+    /**
+     * @var EmailRepository
+     */
+    protected $emailRepository;
+
+
+    public function __construct(EmailRepository $emailRepository)
+    {
+        $this->emailRepository = $emailRepository;
+
+    }
+
+
+    public function post(/*.mixed.*/$data): int
+    {
+        throw new Exception(__CLASS__." Method '__FUNCTION__' not implemented");
+
+    }
+
+
+    public function listAll(): array
+    {
+        throw new Exception(__CLASS__." Method '__FUNCTION__' not implemented");
+
+    }
+
+
+    public function getById(/*.mixed.*/$id): array
+    {
+        throw new Exception(__CLASS__." Method '__FUNCTION__' not implemented");
+
+    }
+
+    
+    public function put(/*.string.*/$id, /*.mixed.*/$data): void
+    {
+        throw new Exception(__CLASS__." Method '__FUNCTION__' not implemented");
+
+    }
+
+
+    public function deleteById(/*.mixed.*/$id): void
+    {
+        throw new Exception(__CLASS__." Method '__FUNCTION__' not implemented");
+
+    }
+
+
+    public function deleteByDepartmentId(/*.mixed.*/$departmentId): void
+    {
+        $this->emailRepository->deleteByDepartmentId($departmentId);
+
+    }
+
+    
+    /* End EmailService */
+}

--- a/api/src/Tests/Cases/DepartmentTest.php
+++ b/api/src/Tests/Cases/DepartmentTest.php
@@ -3,6 +3,7 @@
 namespace App\Tests\TestCase\Controller;
 
 use App\Tests\Base\CiabTestCase;
+use App\Tests\Base\TestRun;
 
 class DepartmentTest extends CiabTestCase
 {
@@ -223,6 +224,23 @@ class DepartmentTest extends CiabTestCase
     }
 
 
+    public function testDeleteDepartment(): void
+    {
+        $department = [
+            "Name" => "Test Delete Department"
+        ];
+        $departmentData = testRun::testRun($this, 'POST', '/department')
+            ->setBody($department)
+            ->run();
+
+        testRun::testRun($this, 'DELETE', "/department/{id}")
+            ->setUriParts(["id" => $departmentData->id])
+            ->setVerifyYaml(true)
+            ->run();
+
+    }
+
+
     public function testGetDepartmentInvalidId(): void
     {
         $this->runRequest('GET', '/department/-1', null, null, 404, null, '/department/{id}');
@@ -416,5 +434,26 @@ class DepartmentTest extends CiabTestCase
     }
 
     
+    public function testDeleteDepartmentInvalidId(): void
+    {
+        testRun::testRun($this, 'DELETE', '/department/{id}')
+            ->setUriParts(["id" => "-1"])
+            ->setExpectedResult(400)
+            ->setVerifyYaml(true)
+            ->run();
+
+    }
+
+    
+    public function testDeleteDepartmentInvalidVeryHighId(): void
+    {
+        testRun::testRun($this, 'DELETE', '/department/{id}')
+            ->setUriParts(["id" => "99999"])
+            ->setVerifyYaml(true)
+            ->run();
+
+    }
+    
+
     /* End */
 }

--- a/api/src/Tests/Cases/Service/DepartmentServiceTest.php
+++ b/api/src/Tests/Cases/Service/DepartmentServiceTest.php
@@ -4,11 +4,16 @@ namespace App\Tests\TestCase\Service;
 
 use App\Repository\DepartmentRepository;
 use App\Service\DepartmentService;
+use App\Service\EmailService;
+use App\Service\EmailListAccessService;
 use PHPUnit\Framework\TestCase;
-use Exception;
 
 final class DepartmentServiceTest extends TestCase
 {
+
+    private $emailServiceStub;
+
+    private $emailAccessListServiceStub;
 
     private $deptRepositoryStub;
 
@@ -20,8 +25,10 @@ final class DepartmentServiceTest extends TestCase
 
     protected function setUp(): void
     {
+        $this->emailServiceStub = $this->createStub(EmailService::class);
+        $this->emailAccessListServiceStub = $this->createStub(EmailListAccessService::class);
         $this->deptRepositoryStub = $this->createStub(DepartmentRepository::class);
-        $this->systemUnderTest = new DepartmentService($this->deptRepositoryStub);
+        $this->systemUnderTest = new DepartmentService($this->emailServiceStub, $this->emailAccessListServiceStub, $this->deptRepositoryStub);
 
     }
 
@@ -164,8 +171,16 @@ final class DepartmentServiceTest extends TestCase
 
     public function testDeleteById()
     {
-        $this->expectException(Exception::class);
-        $this->systemUnderTest->deleteById("1");
+        $deptId = 123;
+
+        $this->emailServiceStub->expects($this->once())
+            ->method('deleteByDepartmentId');
+        $this->emailAccessListServiceStub->expects($this->once())
+            ->method('deleteByDepartmentId');
+        $this->deptRepositoryStub->expects($this->once())
+            ->method('deleteById');
+
+        $this->systemUnderTest->deleteById($deptId);
 
     }
 

--- a/api/src/Tests/Cases/Service/EmailListAccessServiceTest.php
+++ b/api/src/Tests/Cases/Service/EmailListAccessServiceTest.php
@@ -1,0 +1,81 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\TestCase\Service;
+
+use App\Repository\EmailListAccessRepository;
+use App\Service\EmailListAccessService;
+use PHPUnit\Framework\TestCase;
+use Exception;
+
+final class EmailListAccessServiceTest extends TestCase
+{
+
+    private $emailListAccessRepositoryStub;
+
+    /**
+     * @var EmailService
+     */
+    private $systemUnderTest;
+
+
+    protected function setUp(): void
+    {
+        $this->emailListAccessRepositoryStub = $this->createStub(EmailListAccessRepository::class);
+        $this->systemUnderTest = new EmailListAccessService($this->emailListAccessRepositoryStub);
+
+    }
+
+
+    public function testPost(): void
+    {
+        $this->expectException(Exception::class);
+        $this->systemUnderTest->post("id");
+
+    }
+
+
+    public function testListAll(): void
+    {
+        $this->expectException(Exception::class);
+        $this->systemUnderTest->listAll();
+
+    }
+
+
+    public function testGetById(): void
+    {
+        $this->expectException(Exception::class);
+        $this->systemUnderTest->getById("id");
+
+    }
+
+
+    public function testPut(): void
+    {
+        $this->expectException(Exception::class);
+        $this->systemUnderTest->put("id", []);
+
+    }
+
+
+    public function testDeleteById(): void
+    {
+        $this->expectException(Exception::class);
+        $this->systemUnderTest->deleteById("id");
+
+    }
+
+
+    public function testDeleteByDepartmentId(): void
+    {
+        $departmentId = 123;
+        $this->emailListAccessRepositoryStub->expects($this->once())
+            ->method('deleteByDepartmentId');
+
+        $this->systemUnderTest->deleteByDepartmentId($departmentId);
+        
+    }
+
+
+    /* End EmailListAccessServiceTest */
+}

--- a/api/src/Tests/Cases/Service/EmailServiceTest.php
+++ b/api/src/Tests/Cases/Service/EmailServiceTest.php
@@ -1,0 +1,81 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\TestCase\Service;
+
+use App\Repository\EmailRepository;
+use App\Service\EmailService;
+use PHPUnit\Framework\TestCase;
+use Exception;
+
+final class EmailServiceTest extends TestCase
+{
+
+    private $emailRepositoryStub;
+
+    /**
+     * @var EmailService
+     */
+    private $systemUnderTest;
+
+
+    protected function setUp(): void
+    {
+        $this->emailRepositoryStub = $this->createStub(EmailRepository::class);
+        $this->systemUnderTest = new EmailService($this->emailRepositoryStub);
+
+    }
+
+
+    public function testPost(): void
+    {
+        $this->expectException(Exception::class);
+        $this->systemUnderTest->post("id");
+
+    }
+
+
+    public function testListAll(): void
+    {
+        $this->expectException(Exception::class);
+        $this->systemUnderTest->listAll();
+
+    }
+
+
+    public function testGetById(): void
+    {
+        $this->expectException(Exception::class);
+        $this->systemUnderTest->getById("id");
+
+    }
+
+
+    public function testPut(): void
+    {
+        $this->expectException(Exception::class);
+        $this->systemUnderTest->put("id", []);
+
+    }
+
+
+    public function testDeleteById(): void
+    {
+        $this->expectException(Exception::class);
+        $this->systemUnderTest->deleteById("id");
+
+    }
+
+
+    public function testDeleteByDepartmentId(): void
+    {
+        $departmentId = 123;
+        $this->emailRepositoryStub->expects($this->once())
+            ->method('deleteByDepartmentId');
+
+        $this->systemUnderTest->deleteByDepartmentId($departmentId);
+        
+    }
+
+
+    /* End EmailServiceTest */
+}

--- a/ciab.openapi.yaml
+++ b/ciab.openapi.yaml
@@ -686,6 +686,28 @@ paths:
       security:
         -
           ciab_auth: []
+    delete:
+      tags:
+        - departments
+      summary: 'Delete an existing department'
+      parameters:
+        -
+          name: id
+          in: path
+          description: 'ID of the department being deleted'
+          required: true
+          schema:
+            type: integer
+      responses:
+        '204':
+          description: OK
+        '401':
+          $ref: '#/components/responses/401'
+        '400':
+          $ref: '#/components/responses/400'
+      security:
+        -
+          ciab_auth: []
   '/department/{id}/children':
     get:
       tags:


### PR DESCRIPTION
This PR adds an endpoint to Delete Departments/Divisions.

Currently there is no permission attached to this, but the original also lacked any sort of permission check on the back-end. I'm not super fond of this and would like to figure out a strategy for this going forward.

It also looks like maybe I need to include some deletes on `EMails` and `EmailListAccess` tables for this call as well, which is not currently implemented.