### PR TITLE
Update sidebar with ability to add departments

### DIFF
--- a/modules/concom/vue/components/StaffSidebarDepartment.js
+++ b/modules/concom/vue/components/StaffSidebarDepartment.js
@@ -18,17 +18,17 @@ const TEMPLATE = `
         <button class="UI-roundbutton">{{ email }}</button>
         <br/>
       </template>
-      <button class="UI-roundbutton"><i class="fas fa-plus-square"></i></button>
+      <button class="UI-roundbutton" @click="addEmailClicked"><i class="fas fa-plus-square"></i></button>
     </div>
 
-    <button class="UI-redbutton UI-padding UI-margin" v-if="canEditRbac">
+    <button class="UI-redbutton UI-padding UI-margin" v-if="canEditRbac" disabled="departmentId === -1">
       Position Site Permissions (RBAC)
     </button><br/>
 
     <label class="UI-label" for="department_staff_count">Staff Count:</label>
     <input class="UI-input" id="department_staff_count" readonly :value="staffCount" />
 
-    <div>
+    <div v-if="isDivisionToggle">
       <label class="UI-label" for="department_subdepartments">Sub Departments:</label>
       <input class="UI-input" id="department_subdepartments" readonly :value="subDepartments" />
     </div>
@@ -74,8 +74,32 @@ const TEMPLATE = `
   </div>
 `;
 
+function addEmailClicked() {
+  const data = {
+    id: this.departmentId,
+    departmentName: this.departmentName,
+    departmentEmails: this.departmentEmails,
+    departmentPermissions: this.departmentPermissions,
+    staffCount: this.staffCount,
+    subDepartments: this.subDepartments,
+    fallbackDepartment: this.selectedFallbackDepartment,
+    parentDepartment: this.selectedParentDepartment,
+    isDivision: this.isDivisionToggle
+  }
+
+  this.$emit('addEmailClicked', data);
+}
+
 function onSave() {
-  console.log('onSave clicked');
+  const data = {
+    id: this.departmentId,
+    departmentName: this.departmentName,
+    fallbackDepartment: this.selectedFallbackDepartment,
+    parentDepartment: this.selectedParentDepartment,
+    isDivision: this.isDivisionToggle
+  }
+
+  this.$emit('saveDepartmentClicked', data);
 }
 
 function onDelete() {
@@ -84,7 +108,7 @@ function onDelete() {
 
 function setup(props) {
   const departmentId = Vue.ref(props.data?.id ?? -1);
-  const departmentName = Vue.ref(props.data?.departmentName ?? props.data?.isDivision ? 'New Division' : 'New Department');
+  const departmentName = Vue.ref(props.data?.departmentName ?? (props.data?.isDivision ? 'New Division' : 'New Department'));
   const departmentEmails = Vue.ref(props.data?.departmentEmails ?? []);
   const departmentPermissions = Vue.ref(props.data?.departmentPermissions ?? { 'Head': [], 'Sub-Head': [], 'Specialist': [] });
   const staffCount = Vue.ref(props.data?.staffCount ?? 0);
@@ -116,9 +140,10 @@ function setup(props) {
 
 const StaffSidebarDepartment = {
   props: PROPS,
-  emits: [ 'sidebarClosed' ],
+  emits: ['sidebarClosed', 'addEmailClicked', 'saveDepartmentClicked'],
   setup,
   methods: {
+    addEmailClicked,
     onSave,
     onDelete
   },

--- a/modules/concom/vue/components/StaffSidebarEmail.js
+++ b/modules/concom/vue/components/StaffSidebarEmail.js
@@ -1,4 +1,5 @@
 const PROPS = {
+  data: Object,
   edit: Boolean
 }
 
@@ -18,13 +19,14 @@ const TEMPLATE = `
   <div class="UI-center">
     <hr/>
     <button class="UI-eventbutton">Save</button>
-    <button class="UI-yellowbutton">Close</button>
+    <button class="UI-yellowbutton" @click="$emit('closeClicked')">Close</button>
     <button class="UI-redbutton">Delete</button>
   </div>
 `;
 
 const StaffSidebarEmail = {
   props: PROPS,
+  emits: [ 'closeClicked' ],
   template: TEMPLATE
 };
 

--- a/modules/concom/vue/components/StaffStructureSidebar.js
+++ b/modules/concom/vue/components/StaffStructureSidebar.js
@@ -7,10 +7,11 @@ const TEMPLATE = `
   <template v-if="name != null">
     <div class="UI-sidebar-shown UI-fixed">
       <template v-if="name === 'department'">
-        <staff-sidebar-department :data="data" @sidebar-closed="$emit('sidebarClosed')"></staff-sidebar-department>
+        <staff-sidebar-department :data="data" @add-email-clicked="addEmailClicked" 
+          @sidebar-closed="$emit('sidebarClosed')" @save-department-clicked="saveDepartmentClicked"></staff-sidebar-department>
       </template>
       <template v-if="name === 'department_email'">
-        <staff-sidebar-email></staff-sidebar-email>
+        <staff-sidebar-email :data="data" @close-clicked="closeEmailClicked"></staff-sidebar-email>
       </template>
       <template v-if="name === 'department_permissions'">
         <staff-sidebar-department-permissions></staff-sidebar-department-permissions>
@@ -25,9 +26,43 @@ const TEMPLATE = `
   </template>
 `;
 
+function addEmailClicked(data) {
+  const eventData = {
+    eventName: 'displayEmail',
+    sidebarData: data,
+    viewName: this.name,
+    newView: 'department_email',
+    newData: {}
+  }
+
+  this.$emit('sidebarViewChanged', eventData);
+}
+
+function closeEmailClicked() {
+  const eventData = {
+    eventName: 'closeEmail'
+  }
+
+  this.$emit('sidebarViewChanged', eventData);
+}
+
+function saveDepartmentClicked(data) {
+  const eventData = {
+    eventName: 'saveDepartment',
+    sidebarData: data
+  };
+
+  this.$emit('sidebarSaveClicked', eventData);
+}
+
 const StaffStructureSidebar = {
   props: PROPS,
-  emits: [ 'sidebarClosed' ],
+  emits: ['sidebarClosed', 'sidebarViewChanged', 'sidebarSaveClicked'],
+  methods: {
+    addEmailClicked,
+    closeEmailClicked,
+    saveDepartmentClicked
+  },
   template: TEMPLATE
 };
 

--- a/modules/concom/vue/composables/sidebar.js
+++ b/modules/concom/vue/composables/sidebar.js
@@ -1,0 +1,57 @@
+/* globals Vue */
+
+function addDepartmentView(data) {
+  const { division } = data;
+  const sidebarData = {
+    isDivision: division == null,
+    parentDepartment: division
+  }
+
+  return {
+    sidebarData,
+    sidebarName: 'department'
+  }
+}
+
+export function useSidebar() {
+  const showSidebar = Vue.ref(false);
+  const sidebarName = Vue.ref(null);
+  const sidebarData = Vue.ref(null);
+  const storedTempData = Vue.ref([]);
+
+  function prepareSidebar(data) {
+    if (!showSidebar.value) {
+      showSidebar.value = true;
+    }
+
+    if (data.eventName === 'addDepartment') {
+      const viewData = addDepartmentView(data);
+      sidebarName.value = viewData.sidebarName;
+      sidebarData.value = viewData.sidebarData;
+    }
+  }
+
+  function changeSidebar(data) {
+    if (data.eventName === 'displayEmail') {
+      storedTempData.value.push({ data: data.sidebarData, name: data.viewName });
+
+      sidebarData.value = data.newData;
+      sidebarName.value = data.newView;
+    }
+
+    if (data.eventName === 'closeEmail') {
+      const tempData = storedTempData.value.pop();
+
+      sidebarData.value = tempData.data;
+      sidebarName.value = tempData.name;
+    }
+  }
+
+  function closeSidebar() {
+    showSidebar.value = false;
+    sidebarName.value = null;
+    sidebarData.value = null;
+  }
+
+  return { showSidebar, sidebarName, sidebarData, prepareSidebar, changeSidebar, closeSidebar };
+}

--- a/modules/concom/vue/composables/sidebarActions.js
+++ b/modules/concom/vue/composables/sidebarActions.js
@@ -1,0 +1,27 @@
+/* globals apiRequest */
+
+async function saveDepartment(data) {
+  const { sidebarData } = data;
+
+  let params = `Name=${sidebarData.departmentName}`;
+  if (sidebarData.fallbackDepartment?.id != null) {
+    params += `&FallbackID=${sidebarData.fallbackDepartment.id}`;
+  }
+
+  if (sidebarData.parentDepartment?.id != null) {
+    params += `&ParentID=${sidebarData.parentDepartment.id}`;
+  }
+
+  await apiRequest('POST', 'department', params);
+}
+
+
+export function useSidebarActions() {
+  async function saveSidebarData(data) {
+    if (data.eventName === 'saveDepartment') {
+      await saveDepartment(data);
+    }
+  }
+
+  return { saveSidebarData };
+}


### PR DESCRIPTION
This PR adds the ability to create new divisions and departments on the ConCom Structure Page.

We also gain the ability to switch out the sidebar view, starting with emails, without losing the department data we have filled out, and without using multiple rendered sidebars.

It demonstrates how composables allow us to keep our components clean. We will be able to more easily test our components because we can now mock the composable functions.