### PR TITLE
Update Sidebar to Allow Editing of Existing Divisions/Departments

### DIFF
--- a/modules/concom/vue/components/StaffSidebarDepartment.js
+++ b/modules/concom/vue/components/StaffSidebarDepartment.js
@@ -77,13 +77,13 @@ const TEMPLATE = `
 function addEmailClicked() {
   const data = {
     id: this.departmentId,
-    departmentName: this.departmentName,
-    departmentEmails: this.departmentEmails,
-    departmentPermissions: this.departmentPermissions,
+    name: this.departmentName,
+    email: this.departmentEmails,
+    permissions: this.departmentPermissions,
     staffCount: this.staffCount,
-    subDepartments: this.subDepartments,
-    fallbackDepartment: this.selectedFallbackDepartment,
-    parentDepartment: this.selectedParentDepartment,
+    departments: this.subDepartments,
+    fallback: this.selectedFallbackDepartment,
+    parentId: this.selectedParentDepartment,
     isDivision: this.isDivisionToggle
   }
 
@@ -108,19 +108,25 @@ function onDelete() {
 
 function setup(props) {
   const departmentId = Vue.ref(props.data?.id ?? -1);
-  const departmentName = Vue.ref(props.data?.departmentName ?? (props.data?.isDivision ? 'New Division' : 'New Department'));
-  const departmentEmails = Vue.ref(props.data?.departmentEmails ?? []);
-  const departmentPermissions = Vue.ref(props.data?.departmentPermissions ?? { 'Head': [], 'Sub-Head': [], 'Specialist': [] });
+  const departmentName = Vue.ref(props.data?.name ?? (props.data?.isDivision ? 'New Division' : 'New Department'));
+  const departmentEmails = Vue.ref(props.data?.email ?? []);
+  const departmentPermissions = Vue.ref(props.data?.permissions ?? { 'Head': [], 'Sub-Head': [], 'Specialist': [] });
   const staffCount = Vue.ref(props.data?.staffCount ?? 0);
   const subDepartments = Vue.ref(props.data?.subDepartments ?? 0);
-  const selectedFallbackDepartment = Vue.ref(props.data?.fallbackDepartment ?? {});
-  const selectedParentDepartment = Vue.ref(props.data?.parentDepartment ?? {});
   const isDivisionToggle = Vue.ref(props.data?.isDivision ?? props.isDivision);
 
   const canEditRbac = Vue.inject('canEditRbac');
   const divisions = Vue.inject('divisions');
 
-  const fallbackDivisions = divisions.value.filter((division) => division.id !== departmentId);
+  const fallbackDepartment = props.data?.fallback ? divisions.value.find((division) => division.id === props.data?.fallback) : {};
+  const parentDepartment = props.data?.parentId ? divisions.value.find((division) => division.id === props.data?.parentId) : {};
+
+  const selectedFallbackDepartment = Vue.ref(fallbackDepartment);
+  const selectedParentDepartment = Vue.ref(parentDepartment);
+
+  const fallbackReferences = divisions.value.filter((division) => division.fallback != null).map((division) => division.fallback);
+  const fallbackDivisions = divisions.value.filter((division) => division.id !== departmentId &&
+    (fallbackDepartment?.id === division.id || !fallbackReferences.includes(division.fallback)));
 
   return {
     departmentId,

--- a/modules/concom/vue/components/StaffStructureDivision.js
+++ b/modules/concom/vue/components/StaffStructureDivision.js
@@ -10,9 +10,9 @@ const TEMPLATE = `
 </div>
 
 <div class="UI-container UI-margin" v-for="division in divisions" :key="division.name">
-  <span class="CONCOM-division-span">{{ division.name }}</span>
+  <span class="CONCOM-division-span" @dblclick="$emit('editDepartment', division)">{{ division.name }}</span>
   <div class="CONCOM-division-drag-div">
-    <div class="CONCOM-department" v-for="department in division.departments" :key="department.name">
+    <div class="CONCOM-department" @dblclick="$emit('editDepartment', department)" v-for="department in division.departments" :key="department.name">
       {{ department.name }}
     </div>
     <div class="CONCOM-new-department-div">
@@ -24,7 +24,7 @@ const TEMPLATE = `
 
 const StaffStructureDivision = {
   props: PROPS,
-  emits: ['addDivision', 'addDepartment'],
+  emits: ['addDivision', 'addDepartment', 'editDivision', 'editDepartment'],
   template: TEMPLATE
 };
 

--- a/modules/concom/vue/composables/sidebar.js
+++ b/modules/concom/vue/composables/sidebar.js
@@ -4,8 +4,23 @@ function addDepartmentView(data) {
   const { division } = data;
   const sidebarData = {
     isDivision: division == null,
-    parentDepartment: division
+    parentId: division?.id
+  };
+
+  return {
+    sidebarData,
+    sidebarName: 'department'
   }
+}
+
+function editDepartmentView(data) {
+  const { existingData } = data;
+  const isDivision = existingData.departments != null;
+  const sidebarData = {
+    ...existingData,
+    isDivision,
+    subDepartments: existingData.departments?.length ?? 0,
+  };
 
   return {
     sidebarData,
@@ -26,6 +41,10 @@ export function useSidebar() {
 
     if (data.eventName === 'addDepartment') {
       const viewData = addDepartmentView(data);
+      sidebarName.value = viewData.sidebarName;
+      sidebarData.value = viewData.sidebarData;
+    } else if (data.eventName === 'editDepartment') {
+      const viewData = editDepartmentView(data);
       sidebarName.value = viewData.sidebarName;
       sidebarData.value = viewData.sidebarData;
     }

--- a/modules/concom/vue/composables/sidebarActions.js
+++ b/modules/concom/vue/composables/sidebarActions.js
@@ -1,8 +1,6 @@
 /* globals apiRequest */
 
-async function saveDepartment(data) {
-  const { sidebarData } = data;
-
+function getDepartmentParams(sidebarData) {
   let params = `Name=${sidebarData.departmentName}`;
   if (sidebarData.fallbackDepartment?.id != null) {
     params += `&FallbackID=${sidebarData.fallbackDepartment.id}`;
@@ -12,14 +10,32 @@ async function saveDepartment(data) {
     params += `&ParentID=${sidebarData.parentDepartment.id}`;
   }
 
+  return params;
+}
+
+async function saveDepartment(data) {
+  const { sidebarData } = data;
+  const params = getDepartmentParams(sidebarData);
+
   await apiRequest('POST', 'department', params);
+}
+
+async function updateDepartment(data) {
+  const { sidebarData } = data;
+  const params = getDepartmentParams(sidebarData);
+
+  await apiRequest('PUT', `department/${sidebarData.id}`, params);
 }
 
 
 export function useSidebarActions() {
   async function saveSidebarData(data) {
     if (data.eventName === 'saveDepartment') {
-      await saveDepartment(data);
+      if (data.sidebarData?.id > 0) {
+        await updateDepartment(data);
+      } else {
+        await saveDepartment(data);
+      }
     }
   }
 

--- a/modules/concom/vue/views/StaffStructurePage.js
+++ b/modules/concom/vue/views/StaffStructurePage.js
@@ -28,7 +28,8 @@ const TEMPLATE = `
           </template>
           
           <staff-structure-division :divisions="divisions" @add-division="addDepartmentClicked" 
-            @add-department="addDepartmentClicked"></staff-structure-division>
+            @add-department="addDepartmentClicked" @edit-department="editDepartmentClicked" 
+            @edit-division="editDepartmentClicked"></staff-structure-division>
         </div>
       </div>
     </div>
@@ -90,6 +91,13 @@ function addDepartmentClicked(division) {
   });
 }
 
+function editDepartmentClicked(existingData) {
+  this.prepareSidebar({
+    eventName: 'editDepartment',
+    existingData
+  });
+}
+
 function sidebarViewChanged(data) {
   this.changeSidebar(data);
 }
@@ -114,6 +122,7 @@ const StaffStructurePage = {
   created: onCreated,
   methods: {
     addDepartmentClicked,
+    editDepartmentClicked,
     sidebarClosed,
     sidebarViewChanged,
     sidebarSaveClicked


### PR DESCRIPTION
This PR adds the necessary changes to get the sidebar working for existing Divisions and Departments.

Some of the names for fields had to change a bit to match up with what data was actually being passed in when an existing division/department was used.