### PR TITLE
Add route for listing department permissions

### DIFF
--- a/api/src/App/Dependencies.php
+++ b/api/src/App/Dependencies.php
@@ -11,11 +11,13 @@ use App\Repository\EmailListAccessRepository;
 use App\Repository\EmailRepository;
 use App\Repository\EventRepository;
 use App\Repository\MemberRepository;
+use App\Repository\PermissionRepository;
 use App\Service\DepartmentService;
 use App\Service\EmailListAccessService;
 use App\Service\EmailService;
 use App\Service\EventService;
 use App\Service\MemberService;
+use App\Service\PermissionService;
 use Slim\App;
 
 /* setupAPIDependencies */
@@ -57,10 +59,17 @@ function setupAPIDependencies(App $app, array $settings)
         );
     };
 
+    $container['PermissionService'] = function ($c): PermissionService {
+        return new PermissionService(
+            new PermissionRepository($c['db'])
+        );
+    };
+
     $container['DepartmentService'] = function ($c): DepartmentService {
         return new DepartmentService(
             $c->get('EmailService'),
             $c->get('EmailListAccessService'),
+            $c->get('PermissionService'),
             new DepartmentRepository($c['db'])
         );
     };

--- a/api/src/App/Routes.php
+++ b/api/src/App/Routes.php
@@ -38,6 +38,7 @@ function setupAPIRoutes(App $app, $authMiddleware)
             $app->put('/{id}', 'App\Controller\Department\PutDepartment');
             $app->delete('/{id}', 'App\Controller\Department\DeleteDepartment');
             $app->get('/{id}/email', 'App\Controller\Department\GetDepartmentEmail');
+            $app->get('/{id}/permission', 'App\Controller\Department\GetDepartmentPermission');
             $app->get('/{name}', 'App\Controller\Department\GetDepartment');
             $app->get('/{name}/children', 'App\Controller\Department\GetDepartmentChildren');
             $app->get('/{name}/deadlines', 'App\Controller\Deadline\ListDepartmentDeadlines');

--- a/api/src/Controller/Department/BaseDepartment.php
+++ b/api/src/Controller/Department/BaseDepartment.php
@@ -84,6 +84,60 @@
  *      )
  *  )
  *
+ *   @OA\Schema(
+ *     schema="department_permission",
+ *     @OA\Property(
+ *         property="type",
+ *         type="string",
+ *         enum={"department_permission"}
+ *     ),
+ *     @OA\Property(
+ *         property="id",
+ *         type="integer",
+ *         description="The permission ID"
+ *     ),
+ *     @OA\Property(
+ *         property="departmentId",
+ *         type="string",
+ *         description="The department ID"
+ *     ),
+ *     @OA\Property(
+ *         property="position",
+ *         type="string",
+ *         description="The department position"
+ *     ),
+ *     @OA\Property(
+ *         property="name",
+ *         type="string",
+ *         description="The name of the permission"
+ *     ),
+ *     @OA\Property(
+ *         property="note",
+ *         type="string",
+ *         description="The note associated with this permission"
+ *     )
+ *   )
+ *
+ *   @OA\Schema(
+ *     schema="department_permission_list",
+ *     allOf = {
+ *         @OA\Schema(ref="#/components/schemas/resource_list")
+ *     },
+ *     @OA\Property(
+ *         property="type",
+ *         type="string",
+ *         enum={"department_permission_list"}
+ *     ),
+ *     @OA\Property(
+ *         property="data",
+ *         type="array",
+ *         description="List of department permissions",
+ *         @OA\Items(
+ *             ref="#/components/schemas/department_permission"
+ *         )
+ *     )
+ *   )
+ *
  *   @OA\Response(
  *      response="department_not_found",
  *      description="Department not found in the system.",

--- a/api/src/Controller/Department/GetDepartmentPermission.php
+++ b/api/src/Controller/Department/GetDepartmentPermission.php
@@ -1,0 +1,68 @@
+<?php declare(strict_types=1);
+
+/**
+ * @OA\Get(
+ *     tags={"departments"},
+ *     path="/department/{id}/permission",
+ *     summary="List department permissions",
+ *     @OA\Parameter(
+ *         description="The department ID",
+ *         in="path",
+ *         name="id",
+ *         required=true,
+ *         @OA\Schema(type="integer")
+ *     ),
+ *     @OA\Response(
+ *         response=200,
+ *         description="OK",
+ *         @OA\JsonContent(
+ *             ref="#/components/schemas/department_permission_list"
+ *         )
+ *     ),
+ *     @OA\Response(
+ *         response=401,
+ *         ref="#/components/responses/401"
+ *     ),
+ *     security={{"ciab_auth":{}}}
+ * )
+ */
+namespace App\Controller\Department;
+
+use Slim\Container;
+use Slim\Http\Request;
+use Slim\Http\Response;
+
+use App\Service\DepartmentService;
+
+class GetDepartmentPermission extends BaseDepartment
+{
+
+    /**
+     * @var DepartmentService
+     */
+    protected $departmentService;
+
+
+    public function __construct(Container $container)
+    {
+        parent::__construct($container);
+        $this->departmentService = $container->get("DepartmentService");
+        $this->includes = null;
+
+    }
+
+
+    public function buildResource(Request $request, Response $response, $params): array
+    {
+        $output = $this->departmentService->listPermissionsByDepartment($params["id"]);
+        return [
+          \App\Controller\BaseController::LIST_TYPE,
+          $output,
+          array('type' => 'department_permission_list')
+        ];
+
+    }
+
+
+    /* end GetDepartmentPermission */
+}

--- a/api/src/Repository/PermissionRepository.php
+++ b/api/src/Repository/PermissionRepository.php
@@ -1,0 +1,65 @@
+<?php declare(strict_types=1);
+
+namespace App\Repository;
+
+use Exception;
+use Atlas\Query\Select;
+
+class PermissionRepository implements RepositoryInterface
+{
+
+    protected $db;
+
+    
+    public function __construct($db)
+    {
+        $this->db = $db;
+
+    }
+
+
+    public function insert(/*.mixed.*/$data): int
+    {
+        throw new Exception(__CLASS__.": Method '__FUNCTION__' not implemented");
+
+    }
+
+
+    public function selectAll(): array
+    {
+        $select = Select::new($this->db);
+        $select->columns(
+            'PermissionID',
+            'Position',
+            'Permission',
+            'Note'
+        )->from('ConComPermissions');
+
+        return $select->fetchAll();
+
+    }
+
+
+    public function selectById(/*.mixed.*/$id): array
+    {
+        throw new Exception(__CLASS__.": Method '__FUNCTION__' not implemented");
+
+    }
+
+
+    public function update(/*.string.*/$id, /*.mixed.*/$data): void
+    {
+        throw new Exception(__CLASS__.": Method '__FUNCTION__' not implemented");
+
+    }
+
+
+    public function deleteById(/*.mixed.*/$id): void
+    {
+        throw new Exception(__CLASS__.": Method '__FUNCTION__' not implemented");
+
+    }
+
+
+    /* End PermissionRepository */
+}

--- a/api/src/Service/DepartmentService.php
+++ b/api/src/Service/DepartmentService.php
@@ -20,15 +20,21 @@ class DepartmentService implements ServiceInterface
     protected $emailListAccessService;
 
     /**
+     * @var PermissionService
+     */
+    protected $permissionService;
+
+    /**
      * @var DepartmentRepository
      */
     protected $departmentRepository;
 
 
-    public function __construct(EmailService $emailService, EmailListAccessService $emailListAccessService, DepartmentRepository $departmentRepository)
+    public function __construct(EmailService $emailService, EmailListAccessService $emailListAccessService, PermissionService $permissionService, DepartmentRepository $departmentRepository)
     {
         $this->emailService = $emailService;
         $this->emailListAccessService = $emailListAccessService;
+        $this->permissionService = $permissionService;
         $this->departmentRepository = $departmentRepository;
 
     }
@@ -89,6 +95,13 @@ class DepartmentService implements ServiceInterface
     public function listAllEmails(/*.mixed.*/$id): array
     {
         return $this->emailService->listAllByDepartmentId($id);
+        
+    }
+
+
+    public function listPermissionsByDepartment(/*.mixed.*/$id): array
+    {
+        return $this->permissionService->getByDepartmentId($id);
         
     }
 

--- a/api/src/Service/PermissionService.php
+++ b/api/src/Service/PermissionService.php
@@ -1,0 +1,84 @@
+<?php declare(strict_types=1);
+
+namespace App\Service;
+
+use Exception;
+use App\Repository\PermissionRepository;
+
+class PermissionService implements ServiceInterface
+{
+
+    /**
+     * @var PermissionRepository
+     */
+    protected $permissionRepository;
+
+
+    public function __construct(PermissionRepository $permissionRepository)
+    {
+        $this->permissionRepository = $permissionRepository;
+
+    }
+
+
+    public function listAll(): array
+    {
+        throw new Exception(__CLASS__.": Method '__FUNCTION__' not implemented");
+
+    }
+
+
+    public function post(/*.mixed.*/$data): int
+    {
+        throw new Exception(__CLASS__.": Method '__FUNCTION__' not implemented");
+
+    }
+
+
+    public function getById(/*.mixed.*/$id): array
+    {
+        throw new Exception(__CLASS__.": Method '__FUNCTION__' not implemented");
+
+    }
+
+
+    public function put(/*.string.*/$id, /*.mixed.*/$data): void
+    {
+        throw new Exception(__CLASS__.": Method '__FUNCTION__' not implemented");
+
+    }
+
+
+    public function deleteById(/*.mixed.*/$id): void
+    {
+        throw new Exception(__CLASS__.": Method '__FUNCTION__' not implemented");
+
+    }
+
+
+    public function getByDepartmentId(/*.mixed.*/$departmentId): array
+    {
+        $allPermissions = $this->permissionRepository->selectAll();
+
+        $filteredResult = [];
+        foreach ($allPermissions as $permission) {
+            $positionSplit = explode(".", $permission["Position"]);
+            if ($positionSplit[0] == "all" || $positionSplit[0] == $departmentId) {
+                $filteredResult[] = [
+                    "type" => "department_permission",
+                    "id" => $permission["PermissionID"],
+                    "departmentId" => $positionSplit[0],
+                    "position" => $positionSplit[1],
+                    "name" => $permission["Permission"],
+                    "note" => $permission["Note"]
+                ];
+            }
+        }
+
+        return $filteredResult;
+
+    }
+
+
+    /* End PermissionService */
+}

--- a/api/src/Tests/Cases/DepartmentTest.php
+++ b/api/src/Tests/Cases/DepartmentTest.php
@@ -620,5 +620,32 @@ class DepartmentTest extends CiabTestCase
     }
 
 
+    public function testGetDepartmentPermissions(): void
+    {
+        $result = testRun::testRun($this, 'GET', '/department/{id}/permission')
+            ->setUriParts(["id" => 2])
+            ->run();
+
+        foreach ($result->data as $permission) {
+            $deptValue = $permission->departmentId;
+            $this->assertTrue($deptValue == "all" || $deptValue == 2);
+        }
+
+    }
+
+
+    public function testGetDepartmentPermissionsNewDept(): void
+    {
+        $result = testRun::testRun($this, 'GET', '/department/{id}/permission')
+            ->setUriParts(["id" => -1])
+            ->run();
+
+        foreach ($result->data as $permission) {
+            $this->assertTrue($permission->departmentId == "all");
+        }
+
+    }
+
+
     /* End */
 }

--- a/api/src/Tests/Cases/Service/DepartmentServiceTest.php
+++ b/api/src/Tests/Cases/Service/DepartmentServiceTest.php
@@ -6,6 +6,7 @@ use App\Repository\DepartmentRepository;
 use App\Service\DepartmentService;
 use App\Service\EmailService;
 use App\Service\EmailListAccessService;
+use App\Service\PermissionService;
 use PHPUnit\Framework\TestCase;
 
 final class DepartmentServiceTest extends TestCase
@@ -14,6 +15,8 @@ final class DepartmentServiceTest extends TestCase
     private $emailServiceStub;
 
     private $emailAccessListServiceStub;
+
+    private $permissionServiceStub;
 
     private $deptRepositoryStub;
 
@@ -27,8 +30,9 @@ final class DepartmentServiceTest extends TestCase
     {
         $this->emailServiceStub = $this->createStub(EmailService::class);
         $this->emailAccessListServiceStub = $this->createStub(EmailListAccessService::class);
+        $this->permissionServiceStub = $this->createStub(PermissionService::class);
         $this->deptRepositoryStub = $this->createStub(DepartmentRepository::class);
-        $this->systemUnderTest = new DepartmentService($this->emailServiceStub, $this->emailAccessListServiceStub, $this->deptRepositoryStub);
+        $this->systemUnderTest = new DepartmentService($this->emailServiceStub, $this->emailAccessListServiceStub, $this->permissionServiceStub, $this->deptRepositoryStub);
 
     }
 
@@ -193,6 +197,17 @@ final class DepartmentServiceTest extends TestCase
             ->method('listAllByDepartmentId');
 
         $this->systemUnderTest->listAllEmails($deptId);
+        
+    }
+
+
+    public function testListPermissionsByDept()
+    {
+        $deptId = 2;
+
+        $this->permissionServiceStub->expects($this->once())
+            ->method('getByDepartmentId');
+        $this->systemUnderTest->listPermissionsByDepartment($deptId);
         
     }
 

--- a/api/src/Tests/Cases/Service/PermissionServiceTest.php
+++ b/api/src/Tests/Cases/Service/PermissionServiceTest.php
@@ -1,0 +1,124 @@
+<?php declare(strict_types=1);
+
+use App\Repository\PermissionRepository;
+use App\Service\PermissionService;
+use PHPUnit\Framework\TestCase;
+
+final class PermissionServiceTest extends TestCase
+{
+
+    private $permissionRepositoryStub;
+
+    /**
+     * @var PermissionService
+     */
+    private $systemUnderTest;
+
+
+    protected function setUp(): void
+    {
+        $this->permissionRepositoryStub = $this->createStub(PermissionRepository::class);
+        $this->systemUnderTest = new PermissionService($this->permissionRepositoryStub);
+
+    }
+
+
+    public function testListAll(): void
+    {
+        $this->expectException(Exception::class);
+        $this->systemUnderTest->listAll();
+
+    }
+
+
+    public function testPost(): void
+    {
+        $this->expectException(Exception::class);
+        $this->systemUnderTest->post(123);
+
+    }
+
+
+    public function testGetById(): void
+    {
+        $this->expectException(Exception::class);
+        $this->systemUnderTest->getById(123);
+
+    }
+
+
+    public function testPut(): void
+    {
+        $this->expectException(Exception::class);
+        $this->systemUnderTest->put(123, []);
+
+    }
+
+
+    public function testDeleteById(): void
+    {
+        $this->expectException(Exception::class);
+        $this->systemUnderTest->deleteById(123);
+
+    }
+
+
+    public function testGetByDepartmentId(): void
+    {
+        $expected = [
+          0 => [
+            "type" => "department_permission",
+            "id" => 1,
+            "departmentId" => "all",
+            "position" => 1,
+            "name" => "concom.view",
+            "note" => null
+          ],
+          1 => [
+            "type" => "department_permission",
+            "id" => 2,
+            "departmentId" => "all",
+            "position" => 1,
+            "name" => "site.concom.permissions",
+            "note" => null
+          ],
+          2 => [
+            "type" => "department_permission",
+            "id" => 3,
+            "departmentId" => "2",
+            "position" => 1,
+            "name" => "site.concom.structure",
+            "note" => null
+          ]
+        ];
+
+        $this->permissionRepositoryStub->method("selectAll")
+            ->willReturn([
+              0 => [
+                "PermissionID" => 1,
+                "Position" => "all.1",
+                "Permission" => "concom.view",
+                "Note" => null
+              ],
+              1 => [
+                "PermissionID" => 2,
+                "Position" => "all.1",
+                "Permission" => "site.concom.permissions",
+                "Note" => null
+              ],
+              2 => [
+                "PermissionID" => 3,
+                "Position" => "2.1",
+                "Permission" => "site.concom.structure",
+                "Note" => null
+              ]
+            ]);
+
+        $result = $this->systemUnderTest->getByDepartmentId(2);
+        $this->assertEquals($expected, $result);
+
+    }
+
+
+    /* End PermissionServiceTest */
+}

--- a/ciab.openapi.yaml
+++ b/ciab.openapi.yaml
@@ -774,6 +774,31 @@ paths:
       security:
         -
           ciab_auth: []
+  '/department/{id}/permission':
+    get:
+      tags:
+        - departments
+      summary: 'List department permissions'
+      parameters:
+        -
+          name: id
+          in: path
+          description: 'The department ID'
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/department_permission_list'
+        '401':
+          $ref: '#/components/responses/401'
+      security:
+        -
+          ciab_auth: []
   /department:
     get:
       tags:
@@ -4426,6 +4451,50 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/department'
+        -
+          $ref: '#/components/schemas/resource_list'
+        -
+          $ref: '#/components/schemas/BaseController'
+    department_permission:
+      type: object
+      allOf:
+        -
+          properties:
+            type:
+              type: string
+              enum:
+                - department_permission
+            id:
+              description: 'The permission ID'
+              type: integer
+            departmentId:
+              description: 'The department ID'
+              type: string
+            position:
+              description: 'The department position'
+              type: string
+            name:
+              description: 'The name of the permission'
+              type: string
+            note:
+              description: 'The note associated with this permission'
+              type: string
+        -
+          $ref: '#/components/schemas/BaseController'
+    department_permission_list:
+      type: object
+      allOf:
+        -
+          properties:
+            type:
+              type: string
+              enum:
+                - department_permission_list
+            data:
+              description: 'List of department permissions'
+              type: array
+              items:
+                $ref: '#/components/schemas/department_permission'
         -
           $ref: '#/components/schemas/resource_list'
         -


### PR DESCRIPTION
This MR adds the necessary services and repositories for managing RBAC-based permissions on ConCom Structure page. Also includes the new endpoint, tests, etc.