### PR TITLE
Fix an issue that can occur when calling event API for current event

### DIFF
--- a/api/src/Controller/BaseController.php
+++ b/api/src/Controller/BaseController.php
@@ -449,12 +449,15 @@ abstract class BaseController
 
     public static function staticGetEvent($container, string $id)
     {
-        $data = $container->EventService->getById($id);
-        if (empty($data)) {
-            throw new NotFoundException("Event '{$id}' Not Found");
+        if ($id == 'current') {
+            return $container->EventService->getCurrentEvent();
+        } else {
+            $data = $container->EventService->getById($id);
+            if (empty($data)) {
+                throw new NotFoundException("Event '{$id}' Not Found");
+            }
+            return $data[0];
         }
-        return $data[0];
-
     }
 
 


### PR DESCRIPTION
This PR fixes an error that I noticed in the network tab while investigating something for Volunteers. It didn't seem to have much impact on the behavior in the site, but it was something that seemed like it should be fixed either way.