### PR TITLE
Add rendering for adding a permission to a department

### DIFF
--- a/modules/concom/vue/components/StaffSidebarDepartmentPermissions.js
+++ b/modules/concom/vue/components/StaffSidebarDepartmentPermissions.js
@@ -37,7 +37,7 @@ const TEMPLATE = `
               </span>
             </template>
           </template>
-          <span><button class="UI-roundbutton"><i class="fas fa-plus-square"></i></button></span>
+          <span><button class="UI-roundbutton" @click="addPermissionClicked(key)"><i class="fas fa-plus-square"></i></button></span>
         </span><br/>
       </template>
     </div>
@@ -46,6 +46,15 @@ const TEMPLATE = `
     <button class="UI-yellowbutton" @click="$emit('closeClicked')">Close</button>
   </div>
 `;
+
+function addPermissionClicked(positionId) {
+  const data = {
+    departmentId: this.departmentId,
+    positionId
+  }
+
+  this.$emit('addPermissionClicked', data);
+}
 
 function reducePermissions(permissions) {
   return permissions.reduce((acc, current) => {
@@ -111,10 +120,11 @@ async function onCreated() {
 
 const StaffSidebarDepartmentPermissions = {
   props: PROPS,
-  emits: [ 'closeClicked' ],
+  emits: ['closeClicked', 'addPermissionClicked'],
   setup,
   created: onCreated,
   methods: {
+    addPermissionClicked,
     reducePermissions
   },
   template: TEMPLATE

--- a/modules/concom/vue/components/StaffSidebarPermissions.js
+++ b/modules/concom/vue/components/StaffSidebarPermissions.js
@@ -1,40 +1,67 @@
+/* globals Vue */
+const PROPS = {
+  data: Object
+};
+
+// These really ought to live in the database.
+const PERMISSIONS = [
+  { name: 'admin.sudo', description: 'Allowed to change login id to any other users login.' },
+  { name: 'api.get.deadline.all', description: 'Able to get deadlines from all departments.' },
+  { name: 'api.delete.deadline.all', description: 'Able to delete deadlines from all departments.' },
+  { name: 'api.post.deadline.all', description: 'Able to modify deadlines from all departments.' },
+  { name: 'api.put.deadline.all', description: 'Able to add deadlines to all departments.' },
+  { name: 'asset.admin', description: 'Able to upload and change site graphical assets' },
+  { name: 'concom.reports', description: 'Generate a CSV report of the ConCom Membership' },
+  { name: 'concom.view', description: 'View the ConCom list' },
+  { name: 'concom.modify.all', description: 'Remove/modify the concom membership in any department.' },
+  { name: 'concom.add.all', description: 'Add member to the concom of any department.' },
+  { name: 'registration.reports', description: 'Allowed generate reports from convention registration data.' },
+  { name: 'site.admin', description: 'Access to the main site administrator page(Superuser)' },
+  { name: 'site.concom.permissions', description: 'Allowed to change role permissions' },
+  { name: 'site.concom.structure', description: 'Allowed to change concom structure' },
+  { name: 'site.email_lists', description: 'Allowed to change all email lists on system' },
+  { name: 'volunteers.admin', description: 'Allowed administrate volunteer data.' },
+  { name: 'volunteers.reports', description: 'Allowed generate reports from convention volunteer data.' }
+];
+
 const TEMPLATE = `
   <div class="UI-center">
     <h2 class="UI-red">Add Permission</h2>
   </div>
   <div>
     <hr/>
-    <select class="UI-select" style="width:auto" id="updated_perm_perm">
-      <option>admin.sudo</option>
-      <option>api.get.deadline.all</option>
-      <option>api.delete.deadline.all</option>
-      <option>api.post.deadline.all</option>
-      <option>api.put.deadline.all</option>
-      <option>asset.admin</option>
-      <option>concom.reports</option>
-      <option>concom.view</option>
-      <option>concom.modify.all</option>
-      <option>concom.add.all</option>
-      <option>registration.reports</option>
-      <option>site.admin</option>
-      <option>site.concom.permissions</option>
-      <option>site.concom.structure</option>
-      <option>site.email_lists</option>
-      <option>volunteers.admin</option>
-      <option>volunteers.reports</option>
+    <select class="UI-select" style="width:auto" id="updated_perm_perm" v-model="selectedPermission">
+      <option disabled value="">Please select a permission</option>
+      <option v-for="permission in permissionOptions" :key="permission.name" :value="permission">
+        {{ permission.name }}
+      </option>
     </select>
-
-    <input class="UI-hide" id="updated_perm_dept" readonly />
-    <input class="UI-hide" id="updated_perm_position" readonly />
   </div>
   <div class="UI-center">
     <hr/>
-    <button class="UI-eventbutton">Save</button>
-    <button class="UI-yellowbutton">Close</button>
+    <button class="UI-eventbutton" :disabled="selectedPermission?.name == null">Save</button>
+    <button class="UI-yellowbutton" @click="$emit('closeClicked')">Close</button>
   </div>
 `;
 
+function setup(props) {
+  const selectedPermission = Vue.ref({});
+  const permissionOptions = PERMISSIONS;
+  const departmentId = props.data.departmentId;
+  const positionId = props.data.positionId;
+
+  return {
+    selectedPermission,
+    permissionOptions,
+    departmentId,
+    positionId
+  }
+}
+
 const StaffSidebarPermissions = {
+  props: PROPS,
+  emits: [ 'closeClicked' ],
+  setup,
   template: TEMPLATE
 };
 

--- a/modules/concom/vue/components/StaffStructureSidebar.js
+++ b/modules/concom/vue/components/StaffStructureSidebar.js
@@ -17,10 +17,11 @@ const TEMPLATE = `
           @delete-email-clicked="deleteEmailClicked"></staff-sidebar-email>
       </template>
       <template v-if="name === 'department_permissions'">
-        <staff-sidebar-department-permissions :data="data" @close-clicked="closeDepartmentPermissionsClicked"></staff-sidebar-department-permissions>
+        <staff-sidebar-department-permissions :data="data" @close-clicked="closeDepartmentPermissionsClicked"
+          @add-permission-clicked="addPermissionClicked"></staff-sidebar-department-permissions>
       </template>
       <template v-if="name === 'permissions'">
-        <staff-sidebar-permissions></staff-sidebar-permissions>
+        <staff-sidebar-permissions :data="data" @close-clicked="closeAddPermissionClicked"></staff-sidebar-permissions>
       </template>
     </div>
   </template>
@@ -123,6 +124,31 @@ function closeDepartmentPermissionsClicked() {
   this.$emit('sidebarViewChanged', eventData);
 }
 
+function addPermissionClicked(data) {
+  const eventData = {
+    eventName: 'addPermission',
+    viewName: this.name,
+    sidebarData: {
+      departmentId: data.departmentId
+    },
+    newView: 'permissions',
+    newData: {
+      departmentId: data.departmentId,
+      positionId: data.positionId
+    }
+  }
+
+  this.$emit('sidebarViewChanged', eventData);
+}
+
+function closeAddPermissionClicked() {
+  const eventData = {
+    eventName: 'closeAddPermission'
+  }
+
+  this.$emit('sidebarViewChanged', eventData);
+}
+
 const StaffStructureSidebar = {
   props: PROPS,
   emits: ['sidebarClosed', 'sidebarViewChanged', 'sidebarSaveClicked', 'sidebarDeleteClicked'],
@@ -135,7 +161,9 @@ const StaffStructureSidebar = {
     editEmailClicked,
     deleteEmailClicked,
     addDepartmentPermissionsClicked,
-    closeDepartmentPermissionsClicked
+    closeDepartmentPermissionsClicked,
+    addPermissionClicked,
+    closeAddPermissionClicked
   },
   template: TEMPLATE
 };

--- a/modules/concom/vue/composables/sidebar.js
+++ b/modules/concom/vue/composables/sidebar.js
@@ -1,5 +1,8 @@
 /* globals Vue */
 
+const OPEN_VIEW_EVENT_NAMES = ['displayEmail', 'addDepartmentPermissions', 'addPermission'];
+const CLOSE_VIEW_EVENT_NAMES = ['closeEmail', 'closeDepartmentPermissions', 'closeAddPermission'];
+
 function addDepartmentView(data) {
   const { division } = data;
   const sidebarData = {
@@ -64,14 +67,14 @@ export function useSidebar() {
   }
 
   function changeSidebar(data) {
-    if (data.eventName === 'displayEmail' || data.eventName === 'addDepartmentPermissions') {
+    if (OPEN_VIEW_EVENT_NAMES.includes(data.eventName)) {
       storedTempData.value.push({ data: data.sidebarData, name: data.viewName });
 
       sidebarData.value = data.newData;
       sidebarName.value = data.newView;
     }
 
-    if (data.eventName === 'closeEmail' || data.eventName === 'closeDepartmentPermissions') {
+    if (CLOSE_VIEW_EVENT_NAMES.includes(data.eventName)) {
       const tempData = storedTempData.value.pop();
 
       if (tempData != null) {


### PR DESCRIPTION
This PR adds the permissions sidebar screen which displays the dropdown list of permissions to choose from. I kept it in parity with what shows up now, but it would be much more useful to use the descriptions visually in the future.