### PR TITLE
Add missing confirm boxes

### DIFF
--- a/modules/concom/vue/components/StaffSidebarDepartment.js
+++ b/modules/concom/vue/components/StaffSidebarDepartment.js
@@ -1,4 +1,4 @@
-/* globals Vue, showSpinner, hideSpinner */
+/* globals Vue, showSpinner, hideSpinner, confirmbox */
 import { useDepartmentStaff } from '../composables/departmentStaff.js';
 import { useDepartmentEmail } from '../composables/departmentEmail.js';
 
@@ -108,24 +108,42 @@ function addPermissionsClicked() {
   this.$emit('addPermissionsClicked', data);
 }
 
-function onSave() {
-  const data = {
-    id: this.departmentId,
-    departmentName: this.departmentName,
-    fallbackDepartment: this.selectedFallbackDepartment,
-    parentDepartment: this.selectedParentDepartment,
-    isDivision: this.isDivisionToggle
-  };
+async function onSave() {
+  try {
+    const confirmBoxTitle = 'Confirms Position Details';
+    const confirmBoxMessage = 'Are the position details correct?';
 
-  this.$emit('saveDepartmentClicked', data);
+    await confirmbox(confirmBoxTitle, confirmBoxMessage);
+
+    const data = {
+      id: this.departmentId,
+      departmentName: this.departmentName,
+      fallbackDepartment: this.selectedFallbackDepartment,
+      parentDepartment: this.selectedParentDepartment,
+      isDivision: this.isDivisionToggle
+    };
+
+    this.$emit('saveDepartmentClicked', data);
+  } catch (error) {
+    // User canceled.
+  }
 }
 
-function onDelete() {
-  const data = {
-    id: this.departmentId
-  };
+async function onDelete() {
+  try {
+    const confirmBoxTitle = 'Confirms Position Deletion';
+    const confirmBoxMessage = 'Really delete this position?';
 
-  this.$emit('deleteDepartmentClicked', data);
+    await confirmbox(confirmBoxTitle, confirmBoxMessage);
+
+    const data = {
+      id: this.departmentId
+    };
+
+    this.$emit('deleteDepartmentClicked', data);
+  } catch (error) {
+    // User canceled.
+  }
 }
 
 function setup(props) {

--- a/modules/concom/vue/components/StaffSidebarEmail.js
+++ b/modules/concom/vue/components/StaffSidebarEmail.js
@@ -4,8 +4,6 @@ const PROPS = {
   edit: Boolean
 }
 
-const confirmBoxTitle = 'Confirms Email Deletion';
-
 const TEMPLATE = `
   <div class="UI-center">
     <h2 class="UI-red">Position Email</h2>
@@ -23,18 +21,28 @@ const TEMPLATE = `
   </div>
 `;
 
-function onSave() {
-  const data = {
-    id: this.emailId,
-    email: this.email,
-    departmentId: this.departmentId
-  };
+async function onSave() {
+  try {
+    const confirmBoxTitle = 'Confirms Save Email';
+    const confirmBoxMessage = `Really save the e-mail address "${this.email}"?`;
 
-  this.$emit('saveEmailClicked', data);
+    await confirmbox(confirmBoxTitle, confirmBoxMessage);
+
+    const data = {
+      id: this.emailId,
+      email: this.email,
+      departmentId: this.departmentId
+    };
+
+    this.$emit('saveEmailClicked', data);
+  } catch (error) {
+    // User canceled.
+  }
 }
 
 async function onDelete() {
   try {
+    const confirmBoxTitle = 'Confirms Email Deletion';
     const confirmBoxMessage = `Really delete the e-mail address "${this.email}"?`;
     await confirmbox(confirmBoxTitle, confirmBoxMessage);
 

--- a/modules/concom/vue/components/StaffSidebarPermissions.js
+++ b/modules/concom/vue/components/StaffSidebarPermissions.js
@@ -47,7 +47,7 @@ const TEMPLATE = `
 async function onSave() {
   try {
     const confirmBoxTitle = 'Confirms Permission Addition';
-    const confirmBoxMessage = `Really add permission ${this.selectedPermission.name}?`;
+    const confirmBoxMessage = `Really add permission "${this.selectedPermission.name}"?`;
 
     await confirmbox(confirmBoxTitle, confirmBoxMessage);
 


### PR DESCRIPTION
This PR brings the Vue implementation for ConCom Structure up to feature parity. It adds confirm boxes that were previously missing for Adding/Removing Departments, Adding Emails, and fixes a typo in the permission form.