### PR TITLE
Fix for division to dept and vice versa

### DIFF
--- a/api/src/Controller/Department/PutDepartment.php
+++ b/api/src/Controller/Department/PutDepartment.php
@@ -125,8 +125,8 @@ class PutDepartment extends BaseDepartment
             throw new InvalidParameterException("ParentID must be greater than 0");
         }
 
-        if (array_key_exists("FallbackID", $body) && (!is_numeric($body["FallbackID"]) || $body["FallbackID"] <= 0)) {
-            throw new InvalidParameterException("FallbackID must be greater than 0");
+        if (array_key_exists("FallbackID", $body) && (!is_numeric($body["FallbackID"]) || ($body["FallbackID"] < -1 || $body["FallbackID"] == 0))) {
+            throw new InvalidParameterException("FallbackID must be -1 or greater than 0");
         }
 
         return $body;

--- a/api/src/Repository/DepartmentRepository.php
+++ b/api/src/Repository/DepartmentRepository.php
@@ -100,7 +100,12 @@ class DepartmentRepository implements RepositoryInterface
 
         // Fallback
         if (array_key_exists("FallbackID", $data)) {
-            $update->column("FallbackID", $data["FallbackID"]);
+            $fallbackID = $data["FallbackID"];
+            if ($fallbackID == -1) {
+                $fallbackID = null;
+            }
+
+            $update->column("FallbackID", $fallbackID);
         }
 
         if (array_key_exists("ParentID", $data)) {

--- a/api/src/Tests/Cases/DepartmentTest.php
+++ b/api/src/Tests/Cases/DepartmentTest.php
@@ -475,7 +475,7 @@ class DepartmentTest extends CiabTestCase
     }
 
 
-    public function testPutDepartmentInvalidFallbackID(): void
+    public function testPutDepartmentFallbackIDIsZero(): void
     {
         $department = [
             "Name" => "Department Name"
@@ -485,7 +485,7 @@ class DepartmentTest extends CiabTestCase
             ->run();
 
         $body = [
-            "FallbackID" => -1
+            "FallbackID" => 0
         ];
 
         testRun::testRun($this, 'PUT', "/department/{id}")
@@ -494,6 +494,28 @@ class DepartmentTest extends CiabTestCase
             ->setExpectedResult(400)
             ->run();
 
+    }
+
+
+    public function testPutDepartmentFallbackIDIsLessThanNegativeOne(): void
+    {
+        $department = [
+            "Name" => "Department Name"
+        ];
+        $departmentData = testRun::testRun($this, 'POST', '/department')
+            ->setBody($department)
+            ->run();
+
+        $body = [
+            "FallbackID" => -2
+        ];
+
+        testRun::testRun($this, 'PUT', "/department/{id}")
+            ->setUriParts(['id' => $departmentData->id])
+            ->setBody($body)
+            ->setExpectedResult(400)
+            ->run();
+            
     }
 
 

--- a/modules/concom/vue/components/StaffSidebarDepartment.js
+++ b/modules/concom/vue/components/StaffSidebarDepartment.js
@@ -39,7 +39,7 @@ const TEMPLATE = `
     <div v-if="isDivisionToggle">
       <label class="UI-label" for="department_fallback_dept">Fallback For:</label>
       <select class="UI-select" style="width:auto" id="department_fallback_dept" v-model="selectedFallbackDepartment">
-        <option disabled value="">Please select a fallback department</option>
+        <option :key="defaultFallbackDepartment.id" :value="defaultFallbackDepartment">Please select a fallback department</option>
         <option v-for="division in fallbackDivisions" :key="division.id" :value="division">
           {{ division.name }}
         </option>
@@ -184,12 +184,31 @@ function setup(props) {
     loadingValues.some((item) => item.value) ? showSpinner() : hideSpinner();
   });
 
+  // When an existing division or department is toggled to the opposite thing, replace the values so that if it is updated,
+  // it has the correct parent and fallback department values.
+  Vue.watch(isDivisionToggle, () => {
+    if (isDivisionToggle.value) {
+      if (selectedParentDepartment.value?.id != null) {
+        selectedParentDepartment.value.id = departmentId.value;
+      }
+
+      selectedFallbackDepartment.value = fallbackDepartment;
+    } else {
+      if (selectedFallbackDepartment.value?.id != null) {
+        selectedFallbackDepartment.value = { id: -1 };
+      }
+
+      selectedParentDepartment.value = parentDepartment;
+    }
+  });
+
   return {
     departmentId,
     departmentName,
     departmentEmails,
     staffCount,
     subDepartments,
+    defaultFallbackDepartment: { id: -1 },
     selectedFallbackDepartment,
     selectedParentDepartment,
     isDivisionToggle,


### PR DESCRIPTION
This PR addresses a bug in the Vue implementation that prevented a department from being promoted to a division. It also addresses an issue where fallback departments could not be cleared via the UI.